### PR TITLE
[IMP] event_track_assistant: No mashing start date of registration wi…

### DIFF
--- a/event_track_assistant/models/event.py
+++ b/event_track_assistant/models/event.py
@@ -583,8 +583,6 @@ class EventRegistration(models.Model):
                     'max_event': self.event_id.id,
                     'to_date': to_date,
                     'max_to_date': max_to_date}
-        if str(from_date) < fields.Date.context_today(self):
-            wiz_vals['from_date'] = fields.Date.context_today(self)
         return wiz_vals
 
     @api.multi


### PR DESCRIPTION
…th system registration date.
Cuando confirmo el registro de una persona a un evento, no machar la fecha de inicio del registro con la fecha del sistema, si la fecha de inicio del registro es menor que la fecha del sistema.
