### PR TITLE
[IMP] event_registrations_analytic: Change analytic account name, whe…

### DIFF
--- a/event_registration_analytic/wizard/__init__.py
+++ b/event_registration_analytic/wizard/__init__.py
@@ -5,3 +5,4 @@ from . import wiz_event_append_assistant
 from . import wiz_impute_in_presence_from_session
 from . import wiz_event_confirm_assistant
 from . import wiz_event_delete_canceled_registration
+from . import wiz_registration_to_another_event

--- a/event_registration_analytic/wizard/wiz_registration_to_another_event.py
+++ b/event_registration_analytic/wizard/wiz_registration_to_another_event.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models
+
+
+class WizRegistrationToAnotherEvent(models.TransientModel):
+    _inherit = 'wiz.registration.to.another.event'
+
+    def _change_registration_event(self):
+        wiz_append_obj = self.env['wiz.event.append.assistant']
+        super(WizRegistrationToAnotherEvent, self)._change_registration_event()
+        if self.event_registration_id.analytic_account:
+            vals = wiz_append_obj._prepare_data_for_account_not_employee(
+                self.new_event_id, self.event_registration_id)
+            if vals.get('code', False):
+                vals.pop('code')
+            self.event_registration_id.analytic_account.write(vals)


### PR DESCRIPTION
…re change registration event.
Si el registro del evento tiene una cuenta analítica asociada, cuando se cambie de evento al registro, volver a calcular el campo "name" de la cuenta analítica asociada al registro.