### PR TITLE
[IMP] event_track_assistant: Removal date, and notes in event registr…

### DIFF
--- a/event_track_assistant/i18n/es.po
+++ b/event_track_assistant/i18n/es.po
@@ -16,6 +16,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: event_track_assistant
+#: field:event.registration,removal_date:0
+#: field:wiz.event.delete.assistant,removal_date:0
+msgid "Removal date"
+msgstr "Fecha baja"
+
+#. module: event_track_assistant
 #: field:wiz.registration.to.another.event,event_registration_id:0
 msgid "Registration"
 msgstr "Registro"

--- a/event_track_assistant/models/event.py
+++ b/event_track_assistant/models/event.py
@@ -326,6 +326,8 @@ class EventTrackPresence(models.Model):
 class EventRegistration(models.Model):
     _inherit = 'event.registration'
 
+    notes = fields.Text(string='Notes')
+    removal_date = fields.Date(string='Removal date')
     date_start = fields.Datetime(string='Date start')
     date_end = fields.Datetime(string='Date end')
     state = fields.Selection(

--- a/event_track_assistant/tests/test_event_track_assistant.py
+++ b/event_track_assistant/tests/test_event_track_assistant.py
@@ -289,9 +289,7 @@ class TestEventTrackAssistant(common.TransactionCase):
         self.assertEquals(self.partner.session_count, 0)
         self.assertEquals(self.partner.presences_count, 0)
         add_wiz = self.wiz_add_model.with_context(
-            active_ids=self.event.ids).create({
-                'partner': self.partner.id,
-            })
+            active_ids=self.event.ids).create({'partner': self.partner.id})
         add_wiz.action_append()
         self.assertNotEquals(len(self.event.mapped('registration_ids')), 0)
         self.assertNotEquals(self.partner.session_count, 0)
@@ -318,23 +316,31 @@ class TestEventTrackAssistant(common.TransactionCase):
         self.assertNotEquals(registration.state, 'cancel')
         del_wiz = self.wiz_del_model.with_context(
             active_ids=self.event.ids).browse(dict_del_wiz.get('res_id'))
+        del_wiz.write({'removal_date': '2025-12-01',
+                       'notes': 'Registration canceled by system'})
         del_wiz.action_delete()
         self.assertEquals(registration.state, 'cancel')
+        self.assertEquals(registration.removal_date, '2025-12-01')
+        self.assertEquals(registration.notes,
+                          'Registration canceled by system')
 
     def test_event_sessions_delete_past_and_later_date(self):
         self.assertEquals(len(self.event.mapped('registration_ids')), 0)
         add_wiz = self.wiz_add_model.with_context(
-            active_ids=self.event.ids).create({
-                'partner': self.partner.id,
-            })
+            active_ids=self.event.ids).create({'partner': self.partner.id})
         add_wiz.action_append()
         self.assertNotEquals(len(self.event.mapped('registration_ids')), 0)
         del_wiz = self.wiz_del_model.with_context(
-            active_ids=self.event.ids).create({
-                'partner': self.partner.id,
-            })
+            active_ids=self.event.ids).create({'partner': self.partner.id})
+        del_wiz.write({'removal_date': '2025-12-01',
+                       'notes': 'Registration canceled by system'})
         del_wiz.action_delete_past_and_later()
         del_wiz.action_nodelete_past_and_later()
+        registration = self.event.registration_ids[0]
+        self.assertEquals(registration.state, 'cancel')
+        self.assertEquals(registration.removal_date, '2025-12-01')
+        self.assertEquals(registration.notes,
+                          'Registration canceled by system')
 
     def test_event_track_assistant_change_session_hour(self):
         track = self.event.track_ids[0]
@@ -342,9 +348,7 @@ class TestEventTrackAssistant(common.TransactionCase):
         track_date = _convert_to_local_date(track.date, self.env.user.tz)
         new_date = _convert_to_utc_date(track_date, new_hour, self.env.user.tz)
         wiz = self.wiz_change_hour_model.with_context(
-            active_ids=track.ids).create({
-                'new_hour': new_hour,
-            })
+            active_ids=track.ids).create({'new_hour': new_hour})
         wiz.change_session_hour()
         self.assertEquals(track.date, datetime2str(new_date))
 

--- a/event_track_assistant/views/event_event_view.xml
+++ b/event_track_assistant/views/event_event_view.xml
@@ -9,6 +9,7 @@
                 <xpath expr="//field[@name='registration_ids']//tree/field[@name='name']" position="after">
                     <field name="date_start" attrs="{'readonly': [('state','not in',('draft'))]}" />
                     <field name="date_end" attrs="{'readonly': [('state','not in',('draft'))]}" />
+                    <field name="removal_date" readonly="1" />
                 </xpath>
                 <notebook position="inside">
                      <page string="Claims">

--- a/event_track_assistant/views/event_registration_view.xml
+++ b/event_track_assistant/views/event_registration_view.xml
@@ -9,7 +9,8 @@
             <field name="arch" type="xml">
                 <field name="event_id" position="after">
                     <field name="date_start" />
-                    <field name="date_end"  />
+                    <field name="date_end" />
+                    <field name="removal_date" />
                 </field>
                 <button name="registration_open" position="attributes">
                     <attribute name="name">button_registration_open</attribute>
@@ -36,6 +37,17 @@
                         string="Change registration to another event"
                         states="draft,open" type="action" class="oe_highlight"/>
                 </button>
+                <field name="date_closed" position="after">
+                    <field name="date_start" />
+                    <field name="date_end" />
+                    <field name="removal_date" />
+                </field>
+                <xpath expr="/form/sheet/group" position="after">
+                    <group name="notes">
+                        <separator string="Notes" colspan="4" />
+                        <field name="notes" nolabel="1" colspan="4" />
+                    </group>
+                </xpath>
             </field>
         </record>
 

--- a/event_track_assistant/wizard/wiz_event_delete_assistant_view.xml
+++ b/event_track_assistant/wizard/wiz_event_delete_assistant_view.xml
@@ -19,6 +19,10 @@
                         <field name="later_sessions" invisible="1"/>
                         <field name="message"
                             attrs="{'invisible':[('past_sessions','=',False),('later_sessions','=',False)]}"/>
+                        <field name="removal_date"
+                            attrs="{'required':[('past_sessions','=',False),('later_sessions','=',False)]}"/>
+                        <field name="notes" 
+                            attrs="{'required':[('past_sessions','=',False),('later_sessions','=',False)]}"/>
                     </group>
                     <footer>
                         <button name="action_delete" type="object"

--- a/sale_order_create_event_hour/tests/test_sale_order_create_event_hour.py
+++ b/sale_order_create_event_hour/tests/test_sale_order_create_event_hour.py
@@ -154,6 +154,8 @@ class TestSaleOrderCreateEventHour(common.TransactionCase):
         wiz.write(wiz_vals)
         wiz.onchange_dates_and_partner()
         wiz._prepare_track_search_condition(event)
+        wiz_vals.update({'removal_date': '2025-12-01',
+                         'notes': 'Registration canceled by system'})
         wiz = self.wiz_del_model.create(wiz_vals)
         wiz.with_context(
             {'active_ids': [event.id]}).onchange_information()
@@ -197,6 +199,8 @@ class TestSaleOrderCreateEventHour(common.TransactionCase):
                     'max_to_date': '2016-02-28 00:00:00',
                     'from_date': '2016-01-15 00:00:00',
                     'to_date': '2016-02-28 00:00:00',
+                    'removal_date': '2025-12-01',
+                    'notes': 'Registration canceled by system',
                     'partner': self.env.ref('base.res_partner_26').id}
         wiz.write(wiz_vals)
         wiz.with_context(


### PR DESCRIPTION
…ation.

2 nuevos campos en registros de eventos. Fecha de baja, y notas. Cuando se da de baja un registro, en el wizard se introducen estos 2 nuevos campos, y su información queda guardada en el registro.