### PR TITLE
[FIX] event_track_assistant: Fix "Personal events sessions" rule.

### DIFF
--- a/event_track_assistant/security/event_track_assistant.xml
+++ b/event_track_assistant/security/event_track_assistant.xml
@@ -5,7 +5,7 @@
             <field name="name">Personal events sessions</field>
             <field ref="website_event_track.model_event_track" name="model_id"/>
             <field name="groups" eval="[(4, ref('event.group_event_user'))]"/>
-            <field name="domain_force">[('allowed_partners','in',user.partner_id.id)]</field>
+            <field name="domain_force">[('allowed_partner_ids','in',user.partner_id.id)]</field>
         </record>
         <record id="event_rule_all_session" model="ir.rule">
             <field name="name">All events session</field>


### PR DESCRIPTION
Arreglar regla "Personal events sessions". Se estaba haciendo referencia al campo "allowed_partners", cuando se debe de hacer referencia al campo "allowed_partner_ids".