### PR TITLE
[FIX] event_registration_analytic: No delete analytic account when ch…

### DIFF
--- a/event_registration_analytic/__openerp__.py
+++ b/event_registration_analytic/__openerp__.py
@@ -22,7 +22,9 @@
         "event_sale",
         "sale_order_create_event",
         "event_registration_hr_contract",
-        "event_substitution"
+        "event_substitution",
+        "payment_line_menu",
+        "account_payment",
     ],
     "data": [
         "wizard/wiz_event_append_assistant_view.xml",
@@ -38,6 +40,8 @@
         "views/account_analytic_account_view.xml",
         "views/account_invoice_view.xml",
         "views/res_partner_view.xml",
+        "views/payment_order_view.xml",
+        "views/payment_line_view.xml",
     ],
     "installable": True,
     "uninstall_hook": "uninstall_hook",

--- a/event_registration_analytic/i18n/es.po
+++ b/event_registration_analytic/i18n/es.po
@@ -17,6 +17,21 @@ msgstr ""
 "X-Generator: Poedit 1.5.4\n"
 
 #. module: event_registration_analytic
+#: view:event.registration:event_registration_analytic.view_event_registration_form_inh_analytic
+msgid "# Bank accounts"
+msgstr "Num. ctas. bancarias"
+
+#. module: event_registration_analytic
+#: view:event.registration:event_registration_analytic.view_event_registration_form_inh_analytic
+msgid "# Valid mandates"
+msgstr "Num. mandatos validos"
+
+#. module: event_registration_analytic
+#: view:event.registration:event_registration_analytic.view_event_registration_form_inh_analytic
+msgid "Other Information"
+msgstr "Otra información"
+
+#. module: event_registration_analytic
 #: code:addons/event_registration_analytic/models/event.py:172
 #, python-format
 msgid "Event presences"
@@ -31,13 +46,16 @@ msgid "# bank accounts"
 msgstr "Num Ctas. Bancarias"
 
 #. module: event_registration_analytic
+#: field:event.registration,parent_num_bank_accounts:0
 #: view:res.partner:event_registration_analytic.families_search_view
 #: view:res.partner:event_registration_analytic.students_search_view
-#: field:res.partner,num_invoices:0 field:res.partner,parent_num_invoices:0
+#: field:res.partner,num_bank_accounts:0
+#: field:res.partner,parent_num_bank_accounts:0
 msgid "# invoices"
 msgstr "Num. facturas"
 
 #. module: event_registration_analytic
+#: field:event.registration,parent_num_valid_mandates:0
 #: view:res.partner:event_registration_analytic.families_search_view
 #: view:res.partner:event_registration_analytic.students_search_view
 #: field:res.partner,num_valid_mandates:0
@@ -100,6 +118,7 @@ msgid "Analytic Account"
 msgstr "Cuenta analítica"
 
 #. module: event_registration_analytic
+#: view:event.registration:event_registration_analytic.view_event_registration_form_inh_analytic
 #: field:event.registration,analytic_account:0
 msgid "Analytic account"
 msgstr "Cuenta analítica"
@@ -184,6 +203,7 @@ msgstr "Empleado"
 #. module: event_registration_analytic
 #: field:account.invoice,event_id:0
 #: model:ir.model,name:event_registration_analytic.model_event_event
+#: field:payment.line,event_id:0
 msgid "Event"
 msgstr "Evento"
 
@@ -199,6 +219,8 @@ msgstr "Sesiones del evento"
 
 #. module: event_registration_analytic
 #: field:account.invoice,event_address_id:0
+#: view:payment.line:event_registration_analytic.payment_line_search_view_inh_event_analytic
+#: field:payment.line,event_address_id:0
 msgid "Event address"
 msgstr "Dirección evento"
 
@@ -304,6 +326,7 @@ msgstr "Línea pedido venta"
 
 #. module: event_registration_analytic
 #: field:account.invoice,sale_order_id:0
+#: field:payment.line,sale_order_id:0
 msgid "Sale order"
 msgstr "Pedido venta"
 
@@ -323,9 +346,11 @@ msgid "Show create account"
 msgstr "Mostrar crear cuenta"
 
 #. module: event_registration_analytic
-#: field:account.analytic.account,student:0 field:account.invoice,student:0
+#: field:account.analytic.account,student:0
+#: field:account.invoice,student:0
 #: model:crm.case.categ,name:event_registration_analytic.crm_case_categ_student
 #: view:event.event:event_registration_analytic.view_event_form_inh_assistant
+#: field:payment.line,student:0
 msgid "Student"
 msgstr "Estudiante"
 

--- a/event_registration_analytic/models/__init__.py
+++ b/event_registration_analytic/models/__init__.py
@@ -4,3 +4,4 @@
 from . import account
 from . import res_partner
 from . import event
+from . import payment_line

--- a/event_registration_analytic/models/payment_line.py
+++ b/event_registration_analytic/models/payment_line.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models, fields
+
+
+class PaymentLine(models.Model):
+    _inherit = 'payment.line'
+
+    student = fields.Many2one(
+        comodel_name='res.partner', related='ml_inv_ref.student', store=True,
+        string='Student')
+    event_address_id = fields.Many2one(
+        comodel_name='res.partner', related='ml_inv_ref.event_address_id',
+        store=True, string='Event address')
+    event_id = fields.Many2one(
+        comodel_name='event.event', related='ml_inv_ref.event_id', store=True,
+        string='Event')
+    sale_order_id = fields.Many2one(
+        comodel_name='sale.order', related='ml_inv_ref.sale_order_id',
+        store=True, string='Sale order')

--- a/event_registration_analytic/views/event_registration_view.xml
+++ b/event_registration_analytic/views/event_registration_view.xml
@@ -20,7 +20,7 @@
             </field>
         </record>
         <record model="ir.ui.view" id="view_registration_search_inh_analytic">
-            <field name="name">view.event.registration.tree.inh.analytic</field>
+            <field name="name">view.event.registration.search.inh.analytic</field>
             <field name="model">event.registration</field>
             <field name="inherit_id" ref="event.view_registration_search" />
             <field name="arch" type="xml">
@@ -30,6 +30,24 @@
                     <filter string="With bank account" domain="[('parent_num_bank_accounts', '!=', 0)]" />
                     <filter string="With Sepa active" domain="[('parent_num_valid_mandates', '!=', 0)]" />
                 </filter>
+            </field>
+        </record>
+        <record model="ir.ui.view" id="view_event_registration_form_inh_analytic">
+            <field name="name">view.event.registration.form.inh.analytic</field>
+            <field name="model">event.registration</field>
+            <field name="inherit_id" ref="event.view_event_registration_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//group/group//field[@name='partner_id']/../.." position="after">
+                    <group colspan="4">
+                        <group>
+                            <separator string="Other Information" colspan="2"/>
+                            <field name="analytic_account" readonly="1" string="Analytic account"/>
+                            <field name="parent_num_bank_accounts" readonly="1" string="# Bank accounts"/>
+                            <field name="parent_num_valid_mandates" readonly="1" string="# Valid mandates"/>
+                        </group>
+                        <group colspan="2" />
+                    </group>
+                </xpath>
             </field>
         </record>
     </data>

--- a/event_registration_analytic/views/payment_line_view.xml
+++ b/event_registration_analytic/views/payment_line_view.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="payment_line_tree_view_inh_event_analytic">
+            <field name="name">payment.line.tree.view.inh.event.analytic</field>
+            <field name="model">payment.line</field>
+            <field name="inherit_id" ref="payment_line_menu.payment_line_tree_view" />
+            <field name="arch" type="xml">
+               <field name="partner_id" position="after">
+                    <field name="student" />
+                    <field name="event_address_id" />
+               </field>
+               <field name="bank_id" position="after">
+                    <field name="mandate_id" />
+               </field>
+            </field>
+        </record>
+        <record model="ir.ui.view" id="payment_line_search_view_inh_event_analytic">
+            <field name="name">payment.line.search.view.inh.event.analytic</field>
+            <field name="model">payment.line</field>
+            <field name="inherit_id" ref="payment_line_menu.payment_line_search_view" />
+            <field name="arch" type="xml">
+               <field name="ml_maturity_date" position="after">
+                    <field name="event_address_id" />
+               </field>
+               <filter string="Partner" position="after">
+                    <filter string="Event address" domain="[]" context="{'group_by':'event_address_id'}"/>
+               </filter>
+            </field>
+        </record>
+        <record model="ir.ui.view" id="view_payment_line_form_inh_event_analytic">
+            <field name="name">view.payment.line.form.inh.event.analytic</field>
+            <field name="model">payment.line</field>
+            <field name="inherit_id" ref="account_payment.view_payment_line_form" />
+            <field name="arch" type="xml">
+               <group string="Entry Information" position="after">
+                  <group col="4" string="event Information">
+                        <field name="student" readonly="1" />
+                        <field name="event_id" readonly="1" />
+                        <field name="event_address_id" reaonly="1" />
+                        <field name="sale_order_id" readonly="1" />
+                  </group>
+               </group>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/event_registration_analytic/views/payment_order_view.xml
+++ b/event_registration_analytic/views/payment_order_view.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_payment_order_form_inh_event_analytic">
+            <field name="name">view.payment.order.form.inh.event.analytic</field>
+            <field name="model">payment.order</field>
+            <field name="inherit_id" ref="account_payment.view_payment_order_form" />
+            <field name="arch" type="xml">
+               <xpath expr="//tree[@string='Payment Line']/field[@name='partner_id']" position="after">
+                    <field name="student" />
+                    <field name="event_address_id" />
+               </xpath>
+               <xpath expr="//tree[@string='Payment Line']/field[@name='ml_maturity_date']" position="attributes">
+                    <attribute name="invisible">1</attribute>
+               </xpath>
+               <xpath expr="//tree[@string='Payment Line']/field[@name='date']" position="attributes">
+                    <attribute name="invisible">1</attribute>
+               </xpath>
+               <xpath expr="//tree[@string='Payment Line']/field[@name='currency']" position="attributes">
+                    <attribute name="invisible">1</attribute>
+               </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/event_registration_analytic/wizard/wiz_event_append_assistant.py
+++ b/event_registration_analytic/wizard/wiz_event_append_assistant.py
@@ -34,9 +34,14 @@ class WizEventAppendAssistant(models.TransientModel):
                 if registration:
                     self._create_account_for_not_employee_from_wizard(
                         event, registration)
-        if self.create_account and self.registration:
+        elif self.create_account and self.registration:
             self._create_account_for_not_employee_from_wizard(
                 self.registration.event_id, self.registration)
+        elif (not self.create_account and self.registration and
+                self.registration.analytic_account):
+            self.registration.analytic_account.write(
+                self._prepare_data_for_account_not_employee(
+                    self.registration.event_id, self.registration))
         return result
 
     def _create_account_for_not_employee_from_wizard(

--- a/event_registration_analytic/wizard/wiz_registration_to_another_event.py
+++ b/event_registration_analytic/wizard/wiz_registration_to_another_event.py
@@ -8,6 +8,13 @@ class WizRegistrationToAnotherEvent(models.TransientModel):
     _inherit = 'wiz.registration.to.another.event'
 
     def _change_registration_event(self):
+        wiz_append_obj = self.env['wiz.event.append.assistant']
         super(WizRegistrationToAnotherEvent, self)._change_registration_event()
         if self.event_registration_id.analytic_account:
-            self.event_registration_id.analytic_account.unlink()
+            vals = wiz_append_obj._prepare_data_for_account_not_employee(
+                self.new_event_id, self.event_registration_id)
+            vals.pop('code', False)
+            vals.pop('date', False)
+            vals.pop('date_start', False)
+            vals.pop('recurring_next_date', False)
+            self.event_registration_id.analytic_account.write(vals)


### PR DESCRIPTION
…ange event in registration.
Se ha arreglado el error que daba al intentar cambiar de evento a un registro, cuando la cuenta analítica asociada al registro, tenía líneas.
Ahora cuando se modificad el evento a un registro No se borra la cuenta, y se modifican sus datos.

Se a aprovechado también este PR, para mostrar información correspondiente de facturas, y eventos, en las vistas de líneas de pago.