### PR TITLE
[IMP] sale_order_create_event, event_planned_by_sale_line: Fields rea…

### DIFF
--- a/event_planned_by_sale_line/views/sale_order_view.xml
+++ b/event_planned_by_sale_line/views/sale_order_view.xml
@@ -19,8 +19,8 @@
             <field name="inherit_id" ref="sale.view_order_form"/>
             <field name="arch" type="xml">
                 <field name="project_id" position="after">
-                    <field name="product_category" />
-                    <field name="payer" required="1"/>
+                    <field name="product_category" attrs="{'readonly':[('state','not in',('draft','send'))]}" />
+                    <field name="payer" required="1" attrs="{'readonly':[('state','not in',('draft','send'))]}" />
                 </field>
                 <xpath expr="//field[@name='order_line']/tree/field[@name='price_unit']" position="after">
                     <field name="project_by_task" invisible="1"/>

--- a/sale_order_create_event/views/sale_order_view.xml
+++ b/sale_order_create_event/views/sale_order_view.xml
@@ -10,7 +10,7 @@
                     <attribute name="context">{'default_project_by_task': project_by_task, 'default_start_date': project_start_date, 'default_end_date': project_end_date}</attribute>
                 </field>
                 <field name="project_id" position="after">
-                    <field name="project_by_task" required="1" />
+                    <field name="project_by_task" required="1" attrs="{'readonly':[('state','not in',('draft','send'))]}" />
                     <field name="project_start_date" invisible="1"/>
                     <field name="project_end_date" invisible="1"/>
                 </field>


### PR DESCRIPTION
…d only in sale order.
Se han modificado estos dos modulos para que los campos "Categoría de producto, pagador, y proyecto por tarea", del formulario de pedidos de venta, sean de solo lectura cuando el estado del pedido de venta es distinto de borrador, y enviado.