### PR TITLE
[FIX] sale_order_create_event: No show 'Yoy must define the birthdate…

### DIFF
--- a/sale_order_create_event/models/sale_order.py
+++ b/sale_order_create_event/models/sale_order.py
@@ -241,3 +241,13 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         if self.start_hour and self.end_hour:
             self.performance = self.end_hour - self.start_hour
+
+    @api.multi
+    def copy_data(self, default=None):
+        self.ensure_one()
+        if not default:
+            default = {}
+        if self.product_id and self.product_id.recurring_service:
+            default.update({'event_id': False})
+        res = super(SaleOrderLine, self).copy_data(default=default)
+        return res[0] if res else {}

--- a/sale_order_create_event/tests/test_sale_order_create_event.py
+++ b/sale_order_create_event/tests/test_sale_order_create_event.py
@@ -201,3 +201,11 @@ class TestSaleOrderCreateEvent(common.TransactionCase):
             {'active_ids': [event.id]}).action_confirm_assistant()
         self.assertNotEqual(
             registration.state, 'draft', 'Registration not confirmed')
+
+    def test_duplicate_sale_order(self):
+        self.sale_order.project_by_task = 'yes'
+        self.sale_order.action_button_confirm()
+        self.assertTrue(self.sale_order.mapped('order_line.event_id'))
+        copy_sale_order = self.sale_order.copy()
+        self.assertEquals(copy_sale_order.state, 'draft')
+        self.assertFalse(copy_sale_order.mapped('order_line.event_id'))


### PR DESCRIPTION
… for the student' error when confirm sale order.
Cuando se estaba confirmando un pedido de venta generado a partir de otro duplicado, daba el error de que había que definir la fecha de nacimiento para el cliente del pedido de venta.
Esto era debido a que cuando se duplicaba el pedido de venta, en en nuevo resultante, en sus líneas quedaba información del evento origen.