### PR TITLE
[IMP] sale_orde_create_event: No create event session if duration < 0.

### DIFF
--- a/sale_order_create_event/models/sale_order.py
+++ b/sale_order_create_event/models/sale_order.py
@@ -144,12 +144,14 @@ class SaleOrder(models.Model):
             self, event, num_session, line, date):
         vals = self._prepare_session_data_from_sale_line(
             event, num_session, line, date)
-        session = self.env['event.track'].create(vals)
-        if line.service_project_task:
-            session.tasks = [(4, line.service_project_task.id)]
-            duration = sum(
-                line.service_project_task.sessions.mapped('duration'))
-            line.service_project_task.planned_hours = duration
+        session = False
+        if vals.get('duration', False) > 0:
+            session = self.env['event.track'].create(vals)
+            if line.service_project_task:
+                session.tasks = [(4, line.service_project_task.id)]
+                duration = sum(
+                    line.service_project_task.sessions.mapped('duration'))
+                line.service_project_task.planned_hours = duration
         return session
 
     def _prepare_session_data_from_sale_line(


### PR DESCRIPTION
No crear sesion de evento si su duración en menor que cero.