### PR TITLE
[IMP] sale_order_create_event: No copy service_project_task field val…

### DIFF
--- a/sale_order_create_event/models/sale_order.py
+++ b/sale_order_create_event/models/sale_order.py
@@ -249,6 +249,7 @@ class SaleOrderLine(models.Model):
         if not default:
             default = {}
         if self.product_id and self.product_id.recurring_service:
-            default.update({'event_id': False})
+            default.update({'event_id': False,
+                            'service_project_task': False})
         res = super(SaleOrderLine, self).copy_data(default=default)
         return res[0] if res else {}


### PR DESCRIPTION
…ue when duplicate sale order line.

No copiar el valor del campo "service_project_task" cuando se duplica una línea de pedidos de venta.