### PR TITLE
[IMP] sale_order_create_event, sale_order_create_event_hour: Project …

### DIFF
--- a/sale_order_create_event/__openerp__.py
+++ b/sale_order_create_event/__openerp__.py
@@ -25,11 +25,13 @@
         "hr_employee_catch_partner",
         "web_sheet_full_width",
         "web_context_tunnel",
-        "sale_service_recurrence_configurator"
+        "sale_service_recurrence_configurator",
+        "resource"
     ],
     "data": [
         "wizard/wiz_event_append_assistant_view.xml",
         "wizard/wiz_change_session_date_view.xml",
+        "wizard/wiz_recalculate_hour_from_contract_view.xml",
         "views/account_analytic_account_view.xml",
         "views/sale_order_view.xml",
         "views/project_project_view.xml",

--- a/sale_order_create_event/i18n/es.po
+++ b/sale_order_create_event/i18n/es.po
@@ -880,3 +880,24 @@ msgstr "{'partner_id':partner_invoice_id, 'manager_id': user_id, 'default_use_ta
 msgid "The project:  '%s', of sale order,already exist in other event. You must create a new project for saleorder."
 msgstr "El projecto:  '%s', del pedido de venta, ya existe en  otro evento. Debe de crear un nuevo proyecto para el presupuesto."
 
+#. module: sale_order_create_event
+#: field:account.analytic.account,working_hours:0
+#: field:project.project,working_hours:0
+msgid "Working Schedule"
+msgstr "Horario planificado"
+
+#. module: sale_order_create_event
+#: model:ir.actions.act_window,name:sale_order_create_event.action_recalculate_hour_from_date
+msgid "Recalculate date in sessions"
+msgstr "Recalcular fechas en sesiones"
+
+#. module: sale_order_create_event
+#: view:wiz.recalculate.hour.from.contract:sale_order_create_event.wiz_recalculate_hour_from_contract_form
+msgid "Recalculate sessions date"
+msgstr "Recalcular fecha sesiones"
+
+#. module: sale_order_create_event
+#: view:wiz.recalculate.hour.from.contract:sale_order_create_event.wiz_recalculate_hour_from_contract_form
+msgid "Recalculate sessions date from sale contract"
+msgstr "Recalcular fecha sesiones desde contratos de venta"
+

--- a/sale_order_create_event/models/__init__.py
+++ b/sale_order_create_event/models/__init__.py
@@ -7,3 +7,4 @@ from . import project
 from . import event
 from . import res_partner
 from . import product
+from . import resource_calendar

--- a/sale_order_create_event/models/account_analytic_account.py
+++ b/sale_order_create_event/models/account_analytic_account.py
@@ -8,6 +8,8 @@ class AccountAnalyticAccount(models.Model):
     _inherit = 'account.analytic.account'
 
     sale = fields.Many2one(comodel_name='sale.order', string='Sale Order')
+    working_hours = fields.Many2one(
+        comodel_name='resource.calendar', string='Working Schedule')
 
     @api.multi
     def write(self, vals):

--- a/sale_order_create_event/models/resource_calendar.py
+++ b/sale_order_create_event/models/resource_calendar.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# © 2017 Alfredo de la fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models
+from openerp.addons.event_track_assistant._common import _convert_to_utc_date
+
+
+class ResourceCalendar(models.Model):
+    _inherit = 'resource.calendar'
+
+    def _calc_date_and_duration(self, date):
+        lines = self.mapped('attendance_ids').filtered(
+            lambda x: x.dayofweek == str(date.date().weekday()))
+        if not lines:
+            return False, False
+        min_h = min(lines, key=lambda x: x.hour_from)
+        new_date = _convert_to_utc_date(
+            date, min_h.hour_from, tz=self.env.user.tz)
+        duration = sum(x['hour_to'] - x['hour_from'] for x in lines)
+        return new_date, duration

--- a/sale_order_create_event/views/account_analytic_account_view.xml
+++ b/sale_order_create_event/views/account_analytic_account_view.xml
@@ -37,6 +37,16 @@
                 </field>
             </field>
         </record>
+        <record id="view_account_analytic_account_form_inh_sale_event" model="ir.ui.view">
+            <field name="name">view.account.analytic.account.form.inh.sale.event</field>
+            <field name="model">account.analytic.account</field>
+            <field name="inherit_id" ref="analytic.view_account_analytic_account_form" />
+            <field name="arch" type="xml">
+                <field name="date_start" position="before">
+                    <field name="working_hours" context="{'default_name': name}"/>
+                </field>
+            </field>
+        </record>
         <record id="view_account_analytic_account_tree_inh_sale_event" model="ir.ui.view">
             <field name="name">view.account.analytic.account.tree.inh.sale.event</field>
             <field name="model">account.analytic.account</field>

--- a/sale_order_create_event/wizard/__init__.py
+++ b/sale_order_create_event/wizard/__init__.py
@@ -6,3 +6,4 @@ from . import wiz_impute_in_presence_from_session
 from . import wiz_change_session_date
 from . import wiz_event_confirm_assistant
 from . import wiz_event_registration_confirm
+from . import wiz_recalculate_hour_from_contract

--- a/sale_order_create_event/wizard/wiz_recalculate_hour_from_contract.py
+++ b/sale_order_create_event/wizard/wiz_recalculate_hour_from_contract.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import fields, models, api
+
+
+class WizRecalculateHourFromContract(models.TransientModel):
+    _name = 'wiz.recalculate.hour.from.contract'
+
+    name = fields.Char(
+        string='Days', default="Recalculate hour from contract")
+
+    @api.multi
+    def recalculate_session_date(self):
+        self.ensure_one()
+        account_obj = self.env['account.analytic.account']
+        event_obj = self.env['event.event']
+        accounts = account_obj.browse(
+            self.env.context.get('active_ids')).filtered(
+            lambda x: x.sale and x.working_hours)
+        for account in accounts:
+            cond = [('sale_order', '=', account.sale.id)]
+            events = event_obj.search(cond)
+            for session in events.mapped('track_ids'):
+                new_date, duration = (
+                    account.working_hours._calc_date_and_duration(
+                        fields.Datetime.from_string(session.session_date)))
+                if new_date:
+                    session.write({'date': new_date,
+                                   'duration': duration})

--- a/sale_order_create_event/wizard/wiz_recalculate_hour_from_contract_view.xml
+++ b/sale_order_create_event/wizard/wiz_recalculate_hour_from_contract_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="wiz_recalculate_hour_from_contract_form">
+            <field name="name">wiz.recalculate.hour.from.contract.form</field>
+            <field name="model">wiz.recalculate.hour.from.contract</field>
+            <field name="arch" type="xml">
+                <form string="Recalculate sessions date" >
+                    <separator string="Recalculate sessions date from sale contract" />
+                    <field name="name" invisible="1" />
+                    <footer>
+                        <button name="recalculate_session_date" type="object"
+                            string="Recalculate sessions date" class="oe_highlight" />
+                        or
+                        <button string="Cancel" class="oe_link" special="cancel"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+        <act_window id="action_recalculate_hour_from_date"
+            key2="client_action_multi" name="Recalculate date in sessions"
+            res_model="wiz.recalculate.hour.from.contract"
+            src_model="account.analytic.account"
+            view_mode="form" target="new" />
+    </data>
+</openerp>

--- a/sale_order_create_event_hour/models/sale_order.py
+++ b/sale_order_create_event_hour/models/sale_order.py
@@ -30,7 +30,11 @@ class SaleOrder(models.Model):
         vals = super(SaleOrder, self)._prepare_session_data_from_sale_line(
             event, num_session, line, date)
         if line.project_by_task == 'no':
-            vals['date'] = _convert_to_utc_date(
+            new_date = False
+            if self.project_id.working_hours:
+                working = self.project_id.working_hours
+                new_date, duration = working._calc_date_and_duration(date)
+            vals['date'] = new_date or _convert_to_utc_date(
                 date, time=self.project_id.start_time,
                 tz=self.env.user.tz)
         if line.order_id.project_id.type_hour:


### PR DESCRIPTION
…of sale order with planning hours.
A la cuenta analítica de pedidos de venta, se le ha relacionado con el objeto "horario de trabajo", que se tendrá en cuenta a la hora de generar las sesiones de evento.
También se ha creado un nuevo wizard, que se puede lanzar desde cuentas analíticas, para recalcular la fecha de las sesiones.