### PR TITLE
[IMP] event_track_assistant: Remove the "allowed_partner_ids" field f…

### DIFF
--- a/event_track_assistant/views/event_track_presence_view.xml
+++ b/event_track_assistant/views/event_track_presence_view.xml
@@ -19,7 +19,6 @@
             <field name="model">event.track.presence</field>
             <field name="arch" type="xml">
                 <tree string="Session presences">
-                    <field name="allowed_partner_ids" invisible="1"/>
                     <field name="event" />
                     <field name="session" />
                     <field name="session_date" />


### PR DESCRIPTION
…rom the event presences tree view.
Quitar de la vista tree de "presencias", el campo "allowd_partner_ids", para que la respuesta al mostrar las presencias en su vista tree, sea más rápida.