### PR TITLE
[IMP] sale_order_create_event: New object 'History of schedules'.

### DIFF
--- a/sale_order_create_event/README.rst
+++ b/sale_order_create_event/README.rst
@@ -12,6 +12,9 @@ Sale order create event
   are automatically generated. These sessions will be associated with the
   corresponding task.
 
+* If Working hours are defined in the sales order contract, there can be ONLY
+  one row per day of the week.
+
 Credits
 =======
 

--- a/sale_order_create_event/__openerp__.py
+++ b/sale_order_create_event/__openerp__.py
@@ -29,6 +29,7 @@
         "resource"
     ],
     "data": [
+        "security/ir.model.access.csv",
         "wizard/wiz_event_append_assistant_view.xml",
         "wizard/wiz_change_session_date_view.xml",
         "wizard/wiz_recalculate_hour_from_contract_view.xml",
@@ -38,6 +39,7 @@
         "views/project_task_view.xml",
         "views/event_event_view.xml",
         "views/product_view.xml",
+        "views/resource_calendar_view.xml",
     ],
     "installable": True,
 }

--- a/sale_order_create_event/i18n/es.po
+++ b/sale_order_create_event/i18n/es.po
@@ -230,6 +230,7 @@ msgstr "Precio fijo"
 #. module: sale_order_create_event
 #: view:project.task:sale_order_create_event.view_task_form2_inh_sale_create_event
 #: field:project.task,friday:0
+#: selection:resource.calendar.attendance.historical,dayofweek:0
 msgid "Friday"
 msgstr "Viernes"
 
@@ -357,6 +358,7 @@ msgstr "Mayo"
 #. module: sale_order_create_event
 #: view:project.task:sale_order_create_event.view_task_form2_inh_sale_create_event
 #: field:project.task,monday:0
+#: selection:resource.calendar.attendance.historical,dayofweek:0
 msgid "Monday"
 msgstr "Lunes"
 
@@ -555,6 +557,7 @@ msgstr "Línea de pedido de venta"
 #. module: sale_order_create_event
 #: view:project.task:sale_order_create_event.view_task_form2_inh_sale_create_event
 #: field:project.task,saturday:0
+#: selection:resource.calendar.attendance.historical,dayofweek:0
 msgid "Saturday"
 msgstr "Sábado"
 
@@ -605,6 +608,7 @@ msgstr "Suma de las líneas de las hojas de servicios facturadas para este contr
 #. module: sale_order_create_event
 #: view:project.task:sale_order_create_event.view_task_form2_inh_sale_create_event
 #: field:project.task,sunday:0
+#: selection:resource.calendar.attendance.historical,dayofweek:0
 msgid "Sunday"
 msgstr "Domingo"
 
@@ -650,6 +654,7 @@ msgstr "Este producto es un servicio recurrente, pero NO ESTA chequeada solo la 
 #. module: sale_order_create_event
 #: view:project.task:sale_order_create_event.view_task_form2_inh_sale_create_event
 #: field:project.task,thursday:0
+#: selection:resource.calendar.attendance.historical,dayofweek:0
 msgid "Thursday"
 msgstr "Jueves"
 
@@ -716,6 +721,7 @@ msgstr "Total a facturar"
 #. module: sale_order_create_event
 #: view:project.task:sale_order_create_event.view_task_form2_inh_sale_create_event
 #: field:project.task,tuesday:0
+#: selection:resource.calendar.attendance.historical,dayofweek:0
 msgid "Tuesday"
 msgstr "Martes"
 
@@ -744,6 +750,7 @@ msgstr "Usuario sin zona horaria definida"
 #. module: sale_order_create_event
 #: view:project.task:sale_order_create_event.view_task_form2_inh_sale_create_event
 #: field:project.task,wednesday:0
+#: selection:resource.calendar.attendance.historical,dayofweek:0
 msgid "Wednesday"
 msgstr "Miércoles"
 
@@ -900,4 +907,51 @@ msgstr "Recalcular fecha sesiones"
 #: view:wiz.recalculate.hour.from.contract:sale_order_create_event.wiz_recalculate_hour_from_contract_form
 msgid "Recalculate sessions date from sale contract"
 msgstr "Recalcular fecha sesiones desde contratos de venta"
+
+#. module: sale_order_create_event
+#: field:resource.calendar,date_from:0
+msgid "Date from"
+msgstr "Desde fecha"
+
+#. module: sale_order_create_event
+#: model:ir.model,name:sale_order_create_event.model_resource_calendar_attendance_historical
+#: view:resource.calendar:sale_order_create_event.resource_calendar_form_inh_sale_create_event
+#: field:resource.calendar,attendance_historical_ids:0
+msgid "History of schedules"
+msgstr "Histórico de horarios"
+
+#. module: sale_order_create_event
+#: field:resource.calendar.attendance.historical,name:0
+msgid "Name"
+msgstr "Nombre"
+
+#. module: sale_order_create_event
+#: field:resource.calendar.attendance.historical,dayofweek:0
+msgid "day of week"
+msgstr "Día de la semana"
+
+#. module: sale_order_create_event
+#: field:resource.calendar.attendance.historical,date_from:0
+msgid "Starting date"
+msgstr "Fecha de inicio"
+
+#. module: sale_order_create_event
+#: field:resource.calendar.attendance.historical,hour_from:0
+msgid "Work from"
+msgstr "Trabajar desde"
+
+#. module: sale_order_create_event
+#: field:resource.calendar.attendance.historical,hour_to:0
+msgid "Work to"
+msgstr "Trabajar hasta"
+
+#. module: sale_order_create_event
+#: view:resource.calendar:sale_order_create_event.resource_calendar_form_inh_sale_create_event
+msgid "Working hours"
+msgstr "Horas laborables"
+
+#. module: sale_order_create_event
+#: field:project.task,event_address:0
+msgid "Event address"
+msgstr "Dirección del evento"
 

--- a/sale_order_create_event/models/account_analytic_account.py
+++ b/sale_order_create_event/models/account_analytic_account.py
@@ -17,3 +17,23 @@ class AccountAnalyticAccount(models.Model):
                 vals.get('name', False)):
             vals.pop('name')
         return super(AccountAnalyticAccount, self).write(vals)
+
+    @api.multi
+    def _recalculate_sessions_date_from_calendar(self):
+        event_obj = self.env['event.event']
+        for account in self.filtered(lambda x: x.working_hours):
+            cond = [('sale_order', '=', account.sale.id)]
+            events = event_obj.search(cond)
+            for hour in account.working_hours.attendance_ids:
+                for event in events:
+                    date = hour.date_from or account.date_start
+                    for session in event.mapped('track_ids').filtered(
+                        lambda x: x.day == hour.dayofweek and
+                            x.session_date >= date):
+                        new_date, duration = (
+                            account.working_hours._calc_date_and_duration(
+                                fields.Datetime.from_string(
+                                    session.session_date)))
+                        if new_date:
+                            session.write({'date': new_date,
+                                           'duration': duration})

--- a/sale_order_create_event/models/resource_calendar.py
+++ b/sale_order_create_event/models/resource_calendar.py
@@ -1,12 +1,18 @@
 # -*- coding: utf-8 -*-
 # © 2017 Alfredo de la fuente - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-from openerp import models
+from openerp import models, fields, api
 from openerp.addons.event_track_assistant._common import _convert_to_utc_date
 
 
 class ResourceCalendar(models.Model):
     _inherit = 'resource.calendar'
+
+    date_from = fields.Date(string='Date from')
+    attendance_historical_ids = fields.One2many(
+        comodel_name='resource.calendar.attendance.historical',
+        inverse_name='calendar_id', string='History of schedules',
+        copy=False)
 
     def _calc_date_and_duration(self, date):
         lines = self.mapped('attendance_ids').filtered(
@@ -18,3 +24,41 @@ class ResourceCalendar(models.Model):
             date, min_h.hour_from, tz=self.env.user.tz)
         duration = sum(x['hour_to'] - x['hour_from'] for x in lines)
         return new_date, duration
+
+
+class ResourceCalendarAttendance(models.Model):
+    _inherit = 'resource.calendar.attendance'
+
+    @api.multi
+    def write(self, values):
+        historical_obj = self.env['resource.calendar.attendance.historical']
+        if (values.get('dayofweek', False) or values.get('date_from', False) or
+            values.get('hour_from', False) or
+                values.get('hour_to', False)):
+            for line in self:
+                vals = {'name': line.name,
+                        'dayofweek': line.dayofweek,
+                        'date_from': line.date_from,
+                        'hour_from': line.hour_from,
+                        'hour_to': line.hour_to,
+                        'calendar_id': line.calendar_id.id}
+                historical_obj.create(vals)
+        return super(ResourceCalendarAttendance, self).write(values)
+
+
+class ResourceCalendarAttendanceHistorical(models.Model):
+    _name = 'resource.calendar.attendance.historical'
+    _description = 'History of schedules'
+    _order = 'dayofweek, id'
+
+    name = fields.Char(string='Name', required=True)
+    dayofweek = fields.Selection(
+        selection=[('0', 'Monday'), ('1', 'Tuesday'), ('2', 'Wednesday'),
+                   ('3', 'Thursday'), ('4', 'Friday'), ('5', 'Saturday'),
+                   ('6', 'Sunday')], string='day of week')
+    date_from = fields.Date(string='Starting date')
+    hour_from = fields.Float(string='Work from')
+    hour_to = fields.Float(string='Work to')
+    calendar_id = fields.Many2one(
+        comodel_name='resource.calendar', string="Resource's Calendar",
+        ondelete='cascade')

--- a/sale_order_create_event/security/ir.model.access.csv
+++ b/sale_order_create_event/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_resource_calendar_attendance_historical_manager","resource_calendar_attendance_historical","sale_order_create_event.model_resource_calendar_attendance_historical","base.group_system",1,1,1,1
+"access_resource_calendar_attendance_historical_user","resource_calendar_attendance_historical","sale_order_create_event.model_resource_calendar_attendance_historical","base.group_user",1,0,0,0

--- a/sale_order_create_event/tests/test_sale_order_create_event.py
+++ b/sale_order_create_event/tests/test_sale_order_create_event.py
@@ -17,10 +17,12 @@ class TestSaleOrderCreateEvent(SaleOrderCreateEventSetup):
     def test_sale_order_create_event(self):
         self.assertEquals(len(self.project.tasks), 0)
         vals = {'name': 'Resource calendar for test',
-                'attendance_ids': [(0, 0, {'name': 'a',
-                                           'dayofweek': '1',
-                                           'hour_from': 8.00,
-                                           'hour_to': 10.00})]}
+                'attendance_ids':
+                [(0, 0, {'name': 'a',
+                         'dayofweek': '1',
+                         'hour_from': 8.00,
+                         'hour_to': 10.00,
+                         'date_from': self.sale_order.project_id.date_start})]}
         resource = self.env['resource.calendar'].create(vals)
         self.sale_order.project_id.working_hours = resource.id
         self.sale_order.action_button_confirm()
@@ -70,6 +72,13 @@ class TestSaleOrderCreateEvent(SaleOrderCreateEventSetup):
         self.assertEquals(len(event.my_task_ids), event.count_tasks)
         self.sale_order.action_cancel()
         self.assertEquals(self.sale_order.state, 'cancel')
+        self.assertEquals(
+            len(resource.attendance_historical_ids), 1,
+            'Bad resource historical(1)')
+        resource.attendance_ids[0].hour_to = 11.0
+        self.assertEquals(
+            len(resource.attendance_historical_ids), 2,
+            'Bad resource historical(2)')
 
     def test_sale_order_create_event_by_task(self):
         self.sale_order.write({

--- a/sale_order_create_event/views/account_analytic_account_view.xml
+++ b/sale_order_create_event/views/account_analytic_account_view.xml
@@ -43,7 +43,7 @@
             <field name="inherit_id" ref="analytic.view_account_analytic_account_form" />
             <field name="arch" type="xml">
                 <field name="date_start" position="before">
-                    <field name="working_hours" context="{'default_name': name}"/>
+                    <field name="working_hours" context="{'default_name': name, 'default_date_from': date_start}"/>
                 </field>
             </field>
         </record>

--- a/sale_order_create_event/views/project_task_view.xml
+++ b/sale_order_create_event/views/project_task_view.xml
@@ -17,6 +17,9 @@
                 <field name="project_id" position="before">
                     <field name="recurring_service" invisible="1" />
                 </field>
+                <field name="project_id" position="after">
+                    <field name="event_address" />
+                </field>
                  <page string="Extra Info" position="after">
                      <page string="Partners of sessions">
                         <group colspan="4">

--- a/sale_order_create_event/views/resource_calendar_view.xml
+++ b/sale_order_create_event/views/resource_calendar_view.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="resource_calendar_form_inh_sale_create_event" model="ir.ui.view">
+            <field name="name">resource.calendar.form.inh.sale.create_event</field>
+            <field name="model">resource.calendar</field>
+            <field name="inherit_id" ref="resource.resource_calendar_form" />
+            <field name="arch" type="xml">
+                <field name="company_id" position="after">
+                    <field name="date_from" context="{'default_name': name, 'default_date_from': date_start}" invisible="1"/>
+                </field>
+                <field name="attendance_ids" position="replace">
+                    <separator string="Working hours" />
+                    <field name="attendance_ids" context="{'default_date_from': date_from}" >
+                        <tree string="Working Time" editable="top">
+                            <field name="name"/>
+                            <field name="dayofweek"/>
+                            <field name="hour_from" widget="float_time"/>
+                            <field name="hour_to" widget="float_time"/>
+                            <field name="date_from" required="True"/>
+                        </tree>
+                    </field>
+                </field>
+                <field name="leave_ids" position="before">
+                    <separator string="History of schedules" />
+                    <field name="attendance_historical_ids" readonly="1">
+                        <tree >
+                            <field name="calendar_id" invisible="1" />
+                            <field name="name" />
+                            <field name="dayofweek" />
+                            <field name="hour_from" widget="float_time" />
+                            <field name="hour_to" widget="float_time" />
+                            <field name="date_from" />
+                        </tree>
+                    </field>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/sale_order_create_event/wizard/wiz_recalculate_hour_from_contract.py
+++ b/sale_order_create_event/wizard/wiz_recalculate_hour_from_contract.py
@@ -14,17 +14,7 @@ class WizRecalculateHourFromContract(models.TransientModel):
     def recalculate_session_date(self):
         self.ensure_one()
         account_obj = self.env['account.analytic.account']
-        event_obj = self.env['event.event']
         accounts = account_obj.browse(
             self.env.context.get('active_ids')).filtered(
             lambda x: x.sale and x.working_hours)
-        for account in accounts:
-            cond = [('sale_order', '=', account.sale.id)]
-            events = event_obj.search(cond)
-            for session in events.mapped('track_ids'):
-                new_date, duration = (
-                    account.working_hours._calc_date_and_duration(
-                        fields.Datetime.from_string(session.session_date)))
-                if new_date:
-                    session.write({'date': new_date,
-                                   'duration': duration})
+        accounts._recalculate_sessions_date_from_calendar()


### PR DESCRIPTION
Se ha creado el nuevo objeto "Historico de horarios de trabajo", definido en el contrato de pedidos de venta. También se ha cambiado el recalcular el horario de trabajo, desde el contrato de pedidos de venta.