### PR TITLE
[FIX] event_registration_hr_contract: Mark as absent the day when the…

### DIFF
--- a/event_registration_hr_contract/models/hr_contract.py
+++ b/event_registration_hr_contract/models/hr_contract.py
@@ -102,3 +102,9 @@ class HrContract(models.Model):
                'view_type': 'form',
                'domain': [('id', 'in', self.presences.ids)]}
         return res
+
+    def _prepare_partner_day_information(self, absence_type):
+        res = super(HrContract, self)._prepare_partner_day_information(
+            absence_type)
+        res['absence'] = True
+        return res


### PR DESCRIPTION
… employee's calendar is generated.
Marcar el día del calendario del empleado como ausente, cuando se genera el calendario, y dicho día el empleado tiene una baja.