### PR TITLE
[IMP] event_track_assistant, event_registration_analytic: New button "Set To Unconfirmed" in event…

### DIFF
--- a/event_registration_analytic/views/event_event_view.xml
+++ b/event_registration_analytic/views/event_event_view.xml
@@ -37,6 +37,7 @@
                                     <button name="button_registration_open" string="Confirm Registration" states="draft" type="object" icon="gtk-apply"/>
                                     <button name="button_reg_close" string="Attended the Event" states="open" type="object" icon="gtk-jump-to"/>
                                     <button name="new_button_reg_cancel" string="Cancel Registration" states="draft,open" type="object" icon="gtk-cancel"/>
+                                    <button string="Set To Unconfirmed" name="do_draft" states="cancel" type="object" icon="gtk-ok"/>
                                 </tree>
                             </field>
                         </group>
@@ -93,6 +94,7 @@
                             <button name="button_registration_open" string="Confirm Registration" states="draft" type="object" icon="gtk-apply"/>
                             <button name="button_reg_close" string="Attended the Event" states="open" type="object" icon="gtk-jump-to"/>
                             <button name="new_button_reg_cancel" string="Cancel Registration" states="draft,open" type="object" icon="gtk-cancel"/>
+                            <button string="Set To Unconfirmed" name="do_draft" states="cancel" type="object" icon="gtk-ok"/>
                         </tree>
                     </field>
                 </field>

--- a/event_track_assistant/models/event.py
+++ b/event_track_assistant/models/event.py
@@ -149,7 +149,8 @@ class EventEvent(models.Model):
                     active_model='event.registration',
                     default_model='event.registration',
                     default_res_id=registration.id,
-                ).create({'body': body})
+                ).create({'subject': template.subject,
+                          'body': body})
                 wizard.send_mail()
 
 

--- a/event_track_assistant/views/event_event_view.xml
+++ b/event_track_assistant/views/event_event_view.xml
@@ -48,8 +48,16 @@
                     <attribute name="name">button_registration_open</attribute>
                 </xpath>
                 <xpath expr="//field[@name='registration_ids']/tree//button[@name='button_reg_cancel']"
+                       position="after">
+                       <button string="Set To Unconfirmed" name="do_draft" states="cancel" type="object" icon="gtk-ok"/>
+                </xpath>
+                <xpath expr="//field[@name='registration_ids']/tree//button[@name='button_reg_cancel']"
                        position="attributes">
                     <attribute name="name">new_button_reg_cancel</attribute>
+                </xpath>
+                <xpath expr="//field[@name='registration_ids']/form//button[@name='button_reg_cancel']"
+                       position="after">
+                       <button string="Set To Unconfirmed" name="do_draft" states="cancel" type="object" icon="gtk-ok"/>
                 </xpath>
                 <xpath expr="//field[@name='registration_ids']/form//button[@name='button_reg_cancel']"
                        position="attributes">


### PR DESCRIPTION
… form, to registration tree and form view.
Mostrar el botón "Poner como no confirmado" en el tree y form del objeto "registro", en el formulario de eventos.
A la hora de mandar un email desde el evento, coger el asunto de la plantilla, y moverla al email.
Además se ha tenido que tocar el test del módulo "event_registration_hr_contract_hour", para subir el coverals