### PR TITLE
[FIX] event_track_assistant: _common. If tz is False it fails, in that case take UTC

### DIFF
--- a/event_track_assistant/_common.py
+++ b/event_track_assistant/_common.py
@@ -14,6 +14,8 @@ date2str = fields.Date.to_string
 def _convert_to_local_date(date, tz=u'UTC'):
     if not date:
         return False
+    if not tz:
+        tz = u'UTC'
     new_date = str2datetime(date) if isinstance(date, str) else date
     new_date = new_date.replace(tzinfo=utc)
     local_date = new_date.astimezone(timezone(tz)).replace(tzinfo=None)
@@ -23,6 +25,8 @@ def _convert_to_local_date(date, tz=u'UTC'):
 def _convert_to_utc_date(date, time=0.0, tz=u'UTC'):
     if not date:
         return False
+    if not tz:
+        tz = u'UTC'
     date = date2str(date) if isinstance(date, datetype) else date
     date = str2datetime(date) if isinstance(date, str) else date
     date += relativedelta(hours=float(time))
@@ -35,6 +39,8 @@ def _convert_to_utc_date(date, time=0.0, tz=u'UTC'):
 def _convert_time_to_float(date, tz=u'UTC'):
     if not date:
         return False
+    if not tz:
+        tz = u'UTC'
     local_time = _convert_to_local_date(date, tz=tz)
     hour = float(local_time.hour)
     minutes = float(local_time.minute) / 60


### PR DESCRIPTION
Usually tz is passed as self.env.user.tz, but if it is not defined it will be False, so then any conversión will fail, to avoid that easily this seems to be the best option.