### PR TITLE
[FIX] event_track_assistant: Upload allowed partners in presences, if…

### DIFF
--- a/event_registration_analytic/tests/test_event_registration_analytic.py
+++ b/event_registration_analytic/tests/test_event_registration_analytic.py
@@ -14,6 +14,14 @@ class TestEventRegistrationAnalytic(TestSaleOrderCreateEventAssistant):
         super(TestEventRegistrationAnalytic, self).setUp()
         self.del_reg_model = self.env['wiz.event.delete.canceled.registration']
         self.wiz_change_model = self.env['wiz.registration.to.another.event']
+        self.holiday_model = self.env['calendar.holiday']
+        self.registration_model = self.env['event.registration']
+        self.contract_model = self.env['hr.contract']
+        self.calendar_model = self.env['res.partner.calendar']
+        self.wiz_model = self.env['wiz.calculate.workable.festive']
+        self.holidays_model = self.env['hr.holidays']
+        self.substitution_model = self.env['wiz.event.substitution']
+        self.today = fields.Date.from_string(fields.Date.today())
         self.partner.parent_id = self.parent
         self.env['res.partner.bank'].create({
             'state': 'iban',
@@ -48,12 +56,12 @@ class TestEventRegistrationAnalytic(TestSaleOrderCreateEventAssistant):
         self.assertEquals(self.event.count_presences,
                           len(self.event.mapped('track_ids.presences')))
         result = self.event.show_all_registrations()
-        domain = [('id', 'in', self.event.mapped('registration_ids').ids)]
+        domain = [('id', 'in', self.event.registration_ids.ids)]
         self.assertEqual(
             result['domain'], domain, 'Error in show event registration')
         result = self.event.show_teacher_registrations()
         domain = [('id', 'in',
-                   self.event.mapped('employee_registration_ids').ids)]
+                   self.event.employee_registration_ids.ids)]
         self.assertEqual(
             result['domain'], domain,
             'Error in show event teacher registrations')
@@ -72,12 +80,22 @@ class TestEventRegistrationAnalytic(TestSaleOrderCreateEventAssistant):
             self.event.count_registrations +
             self.event.count_teacher_registrations,
             len(self.event.registration_ids))
-        for registration in self.event.registration_ids:
+        self.event.registration_ids.write({'state': 'draft'})
+        self.event.registration_ids[1].unlink()
+        self.event.sale_order.project_id.recurring_invoices = False
+        for registration in self.event.registration_ids.filtered(
+                lambda x: x.state == 'draft'):
             result = registration.button_registration_open()
             wiz_id = result.get('res_id')
             add_wiz = self.wiz_add_model.browse(wiz_id)
-            self.assertFalse(add_wiz.create_account)
+            if teachers:
+                add_wiz.partner = teachers[0].id
+            else:
+                add_wiz.partner = (
+                    self.event.no_employee_registration_ids[0].partner_id.id)
+                add_wiz.partner.employee = self.env.ref('hr.employee_al')
             add_wiz.onchange_partner()
+            self.assertFalse(add_wiz.create_account)
         new_event = self.event.copy()
         wiz_another_vals = {
             'new_event_id': new_event.id,
@@ -101,3 +119,111 @@ class TestEventRegistrationAnalytic(TestSaleOrderCreateEventAssistant):
         del_wiz.delete_canceled_registration()
         self.assertFalse(self.event.registration_ids.filtered(
             lambda x: x.state == 'cancel'))
+
+    def test_event_registration_analytic_substitution(self):
+        calendar_line_vals = {
+            'date': '2016-01-06',
+            'absence_type': self.ref('hr_holidays.holiday_status_comp')}
+        calendar_vals = {'name': 'Holidays calendar',
+                         'lines': [(0, 0, calendar_line_vals)]}
+        self.calendar_holiday = self.holiday_model.create(calendar_vals)
+        contract_vals = {'name': 'Contract 1',
+                         'employee_id': self.ref('hr.employee'),
+                         'partner': self.ref('base.public_partner'),
+                         'type_id':
+                         self.ref('hr_contract.hr_contract_type_emp'),
+                         'wage': 500,
+                         'date_start': '2016-01-02',
+                         'holiday_calendars':
+                         [(6, 0, [self.calendar_holiday.id])]}
+        self.contract = self.contract_model.create(contract_vals)
+        self.env.ref('hr.employee').address_home_id = (
+            self.ref('base.public_partner'))
+        self.env.ref('hr.employee').address_home_id.parent_id = (
+            self.env.ref('base.res_partner_2'))
+        self.env.ref('base.public_partner').employee_id = (
+            self.ref('hr.employee'))
+        self.calendar_holiday.lines[0].write({'date': '2016-01-06'})
+        wiz = self.wiz_model.with_context(
+            {'active_id': self.contract.id}).create({'year': self.today.year})
+        vals = ['year']
+        wiz.with_context(
+            {'active_id': self.contract.id}).default_get(vals)
+        wiz.with_context(
+            {'active_id':
+             self.contract.id}).button_calculate_workables_and_festives()
+        cond = [('partner', '=', self.ref('base.public_partner')),
+                ('year', '=', self.today.year)]
+        calendar = self.calendar_model.search(cond)
+        self.assertNotEqual(
+            len(calendar), 0, 'Calendar not generated for partner')
+        self.partner = self.env['res.partner'].create({
+            'name': 'Partner',
+            'parent_id': self.ref('base.public_partner')
+        })
+        self.user = self.env['res.users'].create({
+            'partner_id': self.partner.id,
+            'login': 'user',
+            'password': 'pass',
+        })
+        employee_vals = {
+            'name': 'Test Employee',
+            'user_id': self.user.id,
+            'address_home_id': self.partner.id
+        }
+        employee_vals.update(
+            self.env['hr.employee'].onchange_user(
+                user_id=employee_vals['user_id'])['value'])
+        self.employee = self.env['hr.employee'].create(employee_vals)
+        self.partner.employee_id = self.employee.id
+        contract_vals = {'name': 'Contract 2',
+                         'employee_id': self.employee.id,
+                         'partner': self.partner.id,
+                         'type_id':
+                         self.ref('hr_contract.hr_contract_type_emp'),
+                         'wage': 500,
+                         'date_start': '2016-01-02',
+                         'holiday_calendars':
+                         [(6, 0, [self.calendar_holiday.id])]}
+        self.contract2 = self.contract_model.create(contract_vals)
+        wiz = self.wiz_model.with_context(
+            {'active_id': self.contract2.id}).create({'year': self.today.year})
+        vals = ['year']
+        wiz.with_context(
+            {'active_id': self.contract2.id}).default_get(vals)
+        wiz.with_context(
+            {'active_id':
+             self.contract2.id}).button_calculate_workables_and_festives()
+        event = self.env.ref('event.event_0')
+        event.seats_max = 0
+        reg_vals = {
+            'partner_id': self.ref('base.public_partner'),
+            'name': 'aaaaaaa',
+            'date_start': event.date_begin,
+            'date_end': event.date_end,
+            'contract': self.contract.id,
+            'employee': self.contract.employee_id.id}
+        event.registration_ids = [(0, 0, reg_vals)]
+        hr_holidays_vals = {'name': 'Employee holidays',
+                            'holiday_type': 'employee',
+                            'holiday_status_id':
+                            self.ref('hr_holidays.holiday_status_comp'),
+                            'employee_id': self.ref('hr.employee'),
+                            'date_from': '2016-01-01 00:00:00',
+                            'date_to': '2025-01-01 00:00:00',
+                            'number_of_days_temp': 1}
+        hr_holidays = self.holidays_model.create(hr_holidays_vals)
+        wiz_vals = {
+            'holiday': hr_holidays.id,
+            'lines': [(0, 0, {'confirm_registration': False,
+                              'event': event.id,
+                              'employee': self.employee.id})]}
+        wiz = self.substitution_model.create(wiz_vals)
+        wiz._validate_employee_contract_and_registration(wiz.lines[0])
+        wiz._validate_employee_calendar(
+            self.today.year, self.today.year, self.partner)
+        all_seats_available = event.seats_available
+        wiz.substitution_employee_from_thread()
+        self.assertEqual(
+            all_seats_available, event.seats_available,
+            'Bad students counter')

--- a/event_registration_analytic/wizard/__init__.py
+++ b/event_registration_analytic/wizard/__init__.py
@@ -7,3 +7,4 @@ from . import wiz_event_confirm_assistant
 from . import wiz_event_delete_canceled_registration
 from . import wiz_registration_to_another_event
 from . import wiz_event_registration_confirm
+from . import wiz_event_substitution

--- a/event_registration_analytic/wizard/wiz_event_substitution.py
+++ b/event_registration_analytic/wizard/wiz_event_substitution.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# (c) 2017 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models
+
+
+class WizEventSubstitution(models.TransientModel):
+    _inherit = 'wiz.event.substitution'
+
+    def substitution_employee_from_thread(self):
+        res = super(
+            WizEventSubstitution, self).substitution_employee_from_thread()
+        for line in self.lines:
+            line.event._compute_seats()
+        return res

--- a/event_track_assistant/i18n/es.po
+++ b/event_track_assistant/i18n/es.po
@@ -1550,3 +1550,13 @@ msgstr "Eventos confirmados"
 msgid "Events not confirmed"
 msgstr "Eventos NO confirmados"
 
+#. module: event_track_assistant
+#: view:event.track.presence:event_track_assistant.event_track_presence_search_view
+msgid "Last month"
+msgstr "Mes anterior"
+
+#. module: event_track_assistant
+#: view:event.track:event_track_assistant.view_event_track_search_inh_assistant
+msgid "Sessions last month"
+msgstr "Sesiones mes anterior"
+

--- a/event_track_assistant/models/marketing_config_settings.py
+++ b/event_track_assistant/models/marketing_config_settings.py
@@ -19,17 +19,21 @@ class MarketingConfigSettings(models.Model):
         param_obj = self.env['ir.config_parameter']
         rec = self._get_parameter(key)
         if rec:
-            rec.value = str(value)
-        else:
-            param_obj.create({'key': key, 'value': str(value)})
+            if not value:
+                rec.unlink()
+            else:
+                rec.value = value
+        elif value:
+            param_obj.create({'key': key, 'value': value})
 
     @api.multi
     def get_default_parameters(self):
         def get_value(key, default=''):
             rec = self._get_parameter(key)
             return rec and rec.value or default
-        return {'show_all_customers_in_presences': get_value(
-            'show.all.customers.in.presences', False)}
+        return {
+            'show_all_customers_in_presences':
+            get_value('show.all.customers.in.presences', False)}
 
     @api.multi
     def set_parameters(self):

--- a/event_track_assistant/views/event_track_presence_view.xml
+++ b/event_track_assistant/views/event_track_presence_view.xml
@@ -58,22 +58,25 @@
                     <field name="state" />
                     <separator/>
                     <group expand="0" string="Period">
-                        <filter string="Current week" name="current_week_filter"
-                                domain="[('session_date','&lt;=', (context_today() + relativedelta(weeks=0, weekday=6)).strftime('%%Y-%%m-%%d')),
-                                ('session_date','&gt;',(context_today() - relativedelta(weeks=1, weekday=6)).strftime('%%Y-%%m-%%d'))]"
-                                help="Display all elements in the current week." />
+                        <filter name="last_month_filter" string="Last month"
+                                domain="[('session_date','&gt;=',(context_today()+relativedelta(months=-1)).strftime('%%Y-%%m-01')),
+                                         ('session_date','&lt;',time.strftime('%%Y-%%m-01'))]" />
                         <filter string="Current month" name="current_month_filter"
                                 domain="[('session_date','&lt;',(context_today()+relativedelta(months=1)).strftime('%%Y-%%m-01')),
                                 ('session_date','&gt;=',time.strftime('%%Y-%%m-01'))]"
                                 help="Display all elements in the current month." />
-                        <filter string="Next week" name="next_week_filter"
-                                domain="[('session_date','&gt;',(context_today()+relativedelta(weeks=0, weekday=6)).strftime('%%Y-%%m-%%d')),
-                                ('session_date','&lt;=',(context_today()+relativedelta(weeks=1, weekday=6)).strftime('%%Y-%%m-%%d'))]"
-                                help="Display all elements in the next week." />
                         <filter string="Next month" name="next_month_filter"
                                 domain="[('session_date','&gt;=',(context_today()+relativedelta(months=1)).strftime('%%Y-%%m-01')),
                                 ('session_date','&lt;',(context_today()+relativedelta(months=2)).strftime('%%Y-%%m-01'))]"
                                 help="Display all elements in the next month." />
+                        <filter string="Current week" name="current_week_filter"
+                                domain="[('session_date','&lt;=', (context_today() + relativedelta(weeks=0, weekday=6)).strftime('%%Y-%%m-%%d')),
+                                ('session_date','&gt;',(context_today() - relativedelta(weeks=1, weekday=6)).strftime('%%Y-%%m-%%d'))]"
+                                help="Display all elements in the current week." />
+                        <filter string="Next week" name="next_week_filter"
+                                domain="[('session_date','&gt;',(context_today()+relativedelta(weeks=0, weekday=6)).strftime('%%Y-%%m-%%d')),
+                                ('session_date','&lt;=',(context_today()+relativedelta(weeks=1, weekday=6)).strftime('%%Y-%%m-%%d'))]"
+                                help="Display all elements in the next week." />
                         <filter string="Pending" name="pending" domain="[('state','=','pending')]"/>
                         <filter string="Completed" name="completed" domain="[('state','=','completed')]"/>
                         <filter string="Canceled" name="canceled" domain="[('state','=','canceled')]"/>

--- a/event_track_assistant/views/event_track_view.xml
+++ b/event_track_assistant/views/event_track_view.xml
@@ -33,6 +33,9 @@
                     <filter string="Sessions next week"
                             domain="[('date','&gt;',(context_today()+relativedelta(weeks=0, weekday=6)).strftime('%%Y-%%m-%%d')),
                                      ('date','&lt;=',(context_today()+relativedelta(weeks=1, weekday=6)).strftime('%%Y-%%m-%%d'))]" />
+                    <filter name="last_month_filter" string="Sessions last month"
+                            domain="[('date','&gt;=',(context_today()+relativedelta(months=-1)).strftime('%%Y-%%m-01')),
+                                     ('date','&lt;',time.strftime('%%Y-%%m-01'))]" />
                     <filter string="Sessions current month"
                             domain="[('date','&lt;',(context_today()+relativedelta(months=1)).strftime('%%Y-%%m-01')),
                                      ('date','&gt;=',time.strftime('%%Y-%%m-01'))]" />


### PR DESCRIPTION
… the user is in the group administrator of events.
Cargar el campo "partners permitidos" del objeto presencias, cuando el usuario conectado es localizado en el grupo "administrador" de eventos. Además se ha mejorado el tiempo de cargar del campo "partners permitidos".
Se ha metido el nuevo filtro"mes anterior" en sesiones, y presencias.
Se ha arreglado errores del test del módulo "event_registration_analytic".