### PR TITLE
[IMP] event_track_assistant: When create presence put context "tracki…

### DIFF
--- a/event_track_assistant/wizard/wiz_event_append_assistant.py
+++ b/event_track_assistant/wizard/wiz_event_append_assistant.py
@@ -261,5 +261,6 @@ class WizEventAppendAssistant(models.TransientModel):
         vals = {'session': track.id,
                 'event': event.id,
                 'partner': self.partner.id}
-        presence = presence_obj.create(vals)
+        presence = presence_obj.with_context(
+            tracking_disable=True).create(vals)
         return presence


### PR DESCRIPTION
…ng_disable" = True.
Poner el campo "tracking_disable" igual a True, cuando se va a crear una presencia. Esto lo que hace es no poner al email que se crea, y que se envía al trabajador, con seguimiento.
El que el correo vaya con seguimiento, retrasa el envío del mismo unos 5 segundos. Esto es mucho cuando se van a dar de alta 260 presencias, como es el caso de algunos clientes.