### PR TITLE
[NEW] sale_order_renovate_event: New scheduler for renovate sale, sal…

### DIFF
--- a/sale_order_renovate_event/README.rst
+++ b/sale_order_renovate_event/README.rst
@@ -1,0 +1,25 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+=========================
+Sale order renovate event
+=========================
+New scheduled "Renovate sales orders with contracts, and events". This new
+scheduled selects sales orders that are associated with an event, and that are
+also associated with a sales contract with the following contract conditions:
+
+* In "open" state, type "contract", with recurring invoice, and her date end
+must be December 31st
+
+The sales order, and her the contract will be duplicated, and the sales order
+will automatically be confirmed, generating the event, registering the
+employees, and confirming the records.
+
+Credits
+=======
+
+Contributors
+------------
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/sale_order_renovate_event/__init__.py
+++ b/sale_order_renovate_event/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2017 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import models

--- a/sale_order_renovate_event/__openerp__.py
+++ b/sale_order_renovate_event/__openerp__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# (c) 2017 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+{
+    "name": "Sale Order Renovate Event",
+    "version": "8.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "AvanzOSC",
+    "website": "http://www.avanzosc.es",
+    "contributors": [
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        "Alfredo de la Fuente <alfredodelafuente@avanzosc.es",
+    ],
+    "category": "Human Resources",
+    "depends": [
+        "sale_order_renovate_contract",
+        "sale_order_create_event"
+    ],
+    "data": [
+        "data/sale_order_renovate_event_data.xml",
+    ],
+    "installable": True,
+}

--- a/sale_order_renovate_event/data/sale_order_renovate_event_data.xml
+++ b/sale_order_renovate_event/data/sale_order_renovate_event_data.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data noupdate="1">
+        <record forcecreate="True" id="ir_cron_renovate_contract_event_action" model="ir.cron">
+            <field name="name">Renovate sales orders with contracts, and events</field>
+            <field eval="False" name="active" />
+            <field name="user_id" ref="base.user_root" />
+            <field name="interval_number">12</field>
+            <field name="interval_type">months</field>
+            <field name="numbercall">-1</field>
+            <field eval="'sale.order'" name="model" />
+            <field eval="'automatic_renovate_contract_event'" name="function" />
+            <field eval="'(None, )'" name="args" />
+        </record>
+    </data>
+</openerp>

--- a/sale_order_renovate_event/i18n/es.po
+++ b/sale_order_renovate_event/i18n/es.po
@@ -1,0 +1,22 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_order_renovate_event
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-12-20 13:59+0000\n"
+"PO-Revision-Date: 2017-12-20 13:59+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_order_renovate_event
+#: model:ir.model,name:sale_order_renovate_event.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venta"
+

--- a/sale_order_renovate_event/models/__init__.py
+++ b/sale_order_renovate_event/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2017 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import sale_order

--- a/sale_order_renovate_event/models/sale_order.py
+++ b/sale_order_renovate_event/models/sale_order.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# (c) 2017 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models, fields, api
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.multi
+    def automatic_renovate_contract_event(self):
+        sale_orders = self.env['sale.order']
+        date = '{}-12-31'.format(
+            int(fields.Date.from_string(fields.Date.today()).year)-1)
+        cond = [('project_id', '!=', False),
+                ('project_id.state', '=', 'open'),
+                ('project_id.type', '=', 'contract'),
+                ('project_id.recurring_invoices', '=', True),
+                ('project_id.date', '=', date)]
+        sales = self.search(cond)
+        for sale in sales:
+            cond = [('sale_order', '=', sale.id)]
+            event = self.env['event.event'].search(cond, limit=1)
+            if event:
+                sale_orders += sale
+        for sale in sale_orders:
+            try:
+                sale._renovate_sale_and_contract_from_wizard()
+                cond = [('generated_from_sale_order', '=', sale.id),
+                        ('order_line', '!=', False)]
+                new_sale = self.env['sale.order'].search(cond, limit=1)
+                new_sale.action_button_confirm()
+            except Exception:
+                continue

--- a/sale_order_renovate_event/tests/__init__.py
+++ b/sale_order_renovate_event/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2017 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import test_sale_order_renovate_event

--- a/sale_order_renovate_event/tests/test_sale_order_renovate_event.py
+++ b/sale_order_renovate_event/tests/test_sale_order_renovate_event.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# © 2017 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+import openerp.tests.common as common
+from openerp import fields
+
+
+class TestSaleOrderRenovateEvent(common.TransactionCase):
+
+    def setUp(self):
+        super(TestSaleOrderRenovateEvent, self).setUp()
+        self.account_model = self.env['account.analytic.account']
+        self.sale_model = self.env['sale.order']
+        self.today = fields.Date.from_string(fields.Date.today())
+        account_vals = {'name': 'Renovate event',
+                        'date_start': "{}-01-01".format(int(self.today.year) -
+                                                        1),
+                        'date': "{}-12-31".format(int(self.today.year) -
+                                                  1),
+                        'state': 'open',
+                        'type': 'contract',
+                        'recurring_invoices': True,
+                        'use_tasks': True}
+        self.account = self.account_model.create(account_vals)
+        self.env['project.project'].create(
+            {'name': 'Renovate event', 'analytic_account_id': self.account.id})
+        self.service_product = self.browse_ref(
+            'product.product_product_consultant')
+        sale_vals = {
+            'name': 'sale order renovate event',
+            'partner_id': self.ref('base.res_partner_1'),
+            'project_id': self.account.id
+        }
+        sale_line_vals = {
+            'product_id': self.service_product.id,
+            'name': self.service_product.name,
+            'product_uom_qty': 7,
+            'product_uom': self.service_product.uom_id.id,
+            'price_unit': self.service_product.list_price,
+            'performance': self.service_product.performance}
+        sale_vals['order_line'] = [(0, 0, sale_line_vals)]
+        self.sale_order = self.sale_model.create(sale_vals)
+        self.event = self.browse_ref('event.event_0')
+        self.event.sale_order = self.sale_order
+
+    def test_sale_order_renovate_event(self):
+        self.sale_order.automatic_renovate_contract_event()
+        cond = [('generated_from_sale_order', '=', self.sale_order.id)]
+        new_sale = self.sale_model.search(cond, limit=1)
+        self.assertEquals(len(new_sale), 1, 'New sale no generated')
+        self.assertEquals(self.sale_order.project_id.state, 'close',
+                          'Bad state for old contract')
+        self.assertEquals(new_sale.project_id.state, 'open',
+                          'Bad state for new contract')


### PR DESCRIPTION
…e contract, and event.
Nuevo planificador para renovar automáticamente pedidos de venta, que tengan un proyecto/contrato asociado, y también que estén relacionado con un evento.