### PR TITLE
[FIX] event_track_assistant: Remove "float-time" widget to export to …

### DIFF
--- a/event_track_assistant/views/event_track_view.xml
+++ b/event_track_assistant/views/event_track_view.xml
@@ -92,9 +92,9 @@
             <field name="arch" type="xml">
                 <field name="event_id" position="after">
                     <field name="date" />
-                    <field name="duration" string="Estimated duration" widget="float_time" sum="duration"/>
+                    <field name="duration" string="Estimated duration" sum="duration"/>
                     <field name="estimated_date_end" />
-                    <field name="real_duration" widget="float_time" sum="real_duration"/>
+                    <field name="real_duration" sum="real_duration"/>
                     <field name="real_date_end" />
                     <field name="presences" />
                     <field name="day" invisible="1"/>


### PR DESCRIPTION
…excel event sessions.
Quitar el widget "float-time" a los 2 campos de duración del objeto sesiones, para que no de error al exportar a excel.