### PR TITLE
[IMP] event_renovate_sale_contract: Treat analytical accounts without…

### DIFF
--- a/event_renovate_sale_contract/README.rst
+++ b/event_renovate_sale_contract/README.rst
@@ -7,6 +7,12 @@ Event renovate sale contract
 ============================
 
 * New wizard for renovate sale order and contract.
+* New wizard for renovate analytic accounts of type "contracts" without sale
+  orders.
+  For an increase of 1.4%, in the wizard will have to define an increase of
+  0.014
+* New wizard in analytic accounts for increase price unit of contract invoice
+  lines, without sale order.
 
 Credits
 =======

--- a/event_renovate_sale_contract/__openerp__.py
+++ b/event_renovate_sale_contract/__openerp__.py
@@ -18,6 +18,7 @@
         "sale_order_create_event"
     ],
     "data": [
+        "views/account_analytic_account_view.xml",
     ],
     "installable": True,
     "auto_install": True,

--- a/event_renovate_sale_contract/i18n/es.po
+++ b/event_renovate_sale_contract/i18n/es.po
@@ -25,3 +25,20 @@ msgstr "Pedido de venta"
 msgid "Wizard for renovate sale contract"
 msgstr "Asistente para renovar contrato sin venta"
 
+#. module: event_renovate_sale_contract
+#: model:ir.model,name:event_renovate_sale_contract.model_wiz_analytic_invoice_line_increase
+msgid "Wizard for increase analytic account invoice lines"
+msgstr "Asistente para incrementar líneas de factura de cuenta analítica"
+
+#. module: event_renovate_sale_contract
+#: view:account.analytic.account:event_renovate_sale_contract.analytic_account_search_view_inh_event_renovate
+msgid "With sale order"
+msgstr "With sale order"
+
+#. module: event_renovate_sale_contract
+#: view:account.analytic.account:event_renovate_sale_contract.analytic_account_search_view_inh_event_renovate
+msgid "Without sale order"
+msgstr "Without sale order"
+
+
+

--- a/event_renovate_sale_contract/tests/test_event_renovate_sale_contract.py
+++ b/event_renovate_sale_contract/tests/test_event_renovate_sale_contract.py
@@ -12,6 +12,7 @@ class TestEventRenovateSaleContract(common.TransactionCase):
         self.account_model = self.env['account.analytic.account']
         self.wiz_model = self.env['wiz.sale.order.renovate.contract']
         self.wiz2_model = self.env['wiz.analytic.account.renovate.contract']
+        self.wiz3_model = self.env['wiz.analytic.invoice.line.increase']
         self.service_product = self.browse_ref(
             'product.product_product_consultant')
         line_vals = {'product_id': self.service_product.id,
@@ -89,3 +90,12 @@ class TestEventRenovateSaleContract(common.TransactionCase):
         self.assertEqual(
             account.recurring_invoice_line_ids[0].price_unit, 101.4,
             'Error in price unit of renovate contract')
+
+    def test_analytic_invoice_line_increase(self):
+        wiz_vals = {'increase': 0.014}
+        wiz = self.wiz3_model.create(wiz_vals)
+        wiz.with_context(
+            {'active_ids': self.account.ids}).increase_account_invoice_line()
+        new_price = self.account.recurring_invoice_line_ids[0].price_unit
+        self.assertEqual(
+            new_price, 101.4, 'Wrong increase for new price')

--- a/event_renovate_sale_contract/views/account_analytic_account_view.xml
+++ b/event_renovate_sale_contract/views/account_analytic_account_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="analytic_account_search_view_inh_event_renovate">
+            <field name="name">analytic.account.search.view.inh.event.renovate</field>
+            <field name="model">account.analytic.account</field>
+            <field name="inherit_id" ref="account.view_account_analytic_account_search" />
+            <field name="arch" type="xml">
+                <filter string="Pending" position="after">
+                    <filter string="With sale order" domain="[('sale','!=',False)]" /> 
+                    <filter string="Without sale order" domain="[('sale','=',False)]" />
+                </filter>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/event_renovate_sale_contract/wizard/__init__.py
+++ b/event_renovate_sale_contract/wizard/__init__.py
@@ -2,3 +2,4 @@
 # (c) 2017 Alfredo de la Fuente - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 from . import wiz_analytic_account_renovate_contract
+from . import wiz_analytic_invoice_line_increase

--- a/event_renovate_sale_contract/wizard/wiz_analytic_invoice_line_increase.py
+++ b/event_renovate_sale_contract/wizard/wiz_analytic_invoice_line_increase.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# (c) 2017 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models
+
+
+class WizAnalyticInvoiceLineIncrease(models.TransientModel):
+    _inherit = 'wiz.analytic.invoice.line.increase'
+
+    def _search_contracts(self):
+        contracts = super(
+            WizAnalyticInvoiceLineIncrease, self)._search_contracts()
+        return contracts.filtered(lambda x: not x.sale)


### PR DESCRIPTION
… sales orders for increase price unit in invoice lines.
Seleccionar cuentas análiticas sin pedidos de venta, para incrementar precio unitario de líneas de factura.
Además se han metido 2 filtros nuevos en cuentas analíticas, para poder filtrar las mismas si tienen o no pedido de venta.