### PR TITLE
[IMP] event_track_assistant, event_registration_analytic: In event re…

### DIFF
--- a/event_registration_analytic/__openerp__.py
+++ b/event_registration_analytic/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 {
     "name": "Event Registration Analytic",
-    "version": "8.0.2.0.0",
+    "version": "8.0.2.1.0",
     "license": "AGPL-3",
     "author": "AvanzOSC",
     "website": "http://www.avanzosc.es",

--- a/event_registration_analytic/tests/test_event_registration_analytic.py
+++ b/event_registration_analytic/tests/test_event_registration_analytic.py
@@ -102,7 +102,7 @@ class TestEventRegistrationAnalytic(TestSaleOrderCreateEventAssistant):
         }
         registration = self.event.registration_ids[0]
         change_wiz = self.wiz_change_model.with_context(
-            active_id=self.event.registration_ids[0].id).create(
+            active_ids=[self.event.registration_ids[0].id]).create(
             wiz_another_vals)
         change_wiz.button_change_registration_event()
         self.assertEqual(

--- a/event_registration_analytic/wizard/wiz_registration_to_another_event.py
+++ b/event_registration_analytic/wizard/wiz_registration_to_another_event.py
@@ -7,14 +7,15 @@ from openerp import models
 class WizRegistrationToAnotherEvent(models.TransientModel):
     _inherit = 'wiz.registration.to.another.event'
 
-    def _change_registration_event(self):
+    def _change_registration_event(self, registration):
         wiz_append_obj = self.env['wiz.event.append.assistant']
-        super(WizRegistrationToAnotherEvent, self)._change_registration_event()
-        if self.event_registration_id.analytic_account:
+        super(WizRegistrationToAnotherEvent, self)._change_registration_event(
+            registration)
+        if registration.analytic_account:
             vals = wiz_append_obj._prepare_data_for_account_not_employee(
-                self.new_event_id, self.event_registration_id)
+                self.new_event_id, registration)
             vals.pop('code', False)
             vals.pop('date', False)
             vals.pop('date_start', False)
             vals.pop('recurring_next_date', False)
-            self.event_registration_id.analytic_account.write(vals)
+            registration.analytic_account.write(vals)

--- a/event_track_assistant/__openerp__.py
+++ b/event_track_assistant/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 {
     "name": "Event Track Assistant",
-    "version": "8.0.1.0.0",
+    "version": "8.0.1.1.0",
     "license": "AGPL-3",
     "author": "AvanzOSC",
     "website": "http://www.avanzosc.es",

--- a/event_track_assistant/tests/test_event_track_assistant_only.py
+++ b/event_track_assistant/tests/test_event_track_assistant_only.py
@@ -151,14 +151,13 @@ class TestEventTrackAssistantOnly(EventTrackAssistantSetup):
         wiz_another_vals = {
             'new_event_id': new_event.id,
         }
+        previous_state = registration.state
         change_wiz = self.wiz_change_event_model.with_context(
-            active_id=registration.id).create(wiz_another_vals)
-        self.assertEquals(change_wiz.event_id, registration.event_id)
-        self.assertEquals(change_wiz.event_registration_id, registration)
+            active_ids=registration.ids).create(wiz_another_vals)
         change_wiz.button_change_registration_event()
         self.assertNotEquals(self.event, registration.event_id)
         self.assertEquals(new_event, registration.event_id)
-        self.assertEquals(registration.state, 'draft')
+        self.assertEquals(registration.state, previous_state)
         partner_presences = self.event.mapped('track_ids.presences').filtered(
             lambda x: x.partner == self.partner)
         self.assertFalse(

--- a/event_track_assistant/views/event_registration_view.xml
+++ b/event_track_assistant/views/event_registration_view.xml
@@ -31,11 +31,6 @@
                 <button name="button_reg_cancel" position="attributes">
                     <attribute name="name">new_button_reg_cancel</attribute>
                 </button>
-                <button name="button_reg_close" position="after">
-                    <button name="%(action_change_registration_new_event)d"
-                        string="Change registration to another event"
-                        states="draft,open" type="action" class="oe_highlight"/>
-                </button>
                 <field name="date_closed" position="after">
                     <field name="date_start" />
                     <field name="date_end" />

--- a/event_track_assistant/views/event_track_view.xml
+++ b/event_track_assistant/views/event_track_view.xml
@@ -92,9 +92,9 @@
             <field name="arch" type="xml">
                 <field name="event_id" position="after">
                     <field name="date" />
-                    <field name="duration" string="Estimated duration" sum="duration"/>
+                    <field name="duration" string="Estimated duration" widget="float_time" sum="duration" />
                     <field name="estimated_date_end" />
-                    <field name="real_duration" sum="real_duration"/>
+                    <field name="real_duration" widget="float_time" sum="real_duration"/>
                     <field name="real_date_end" />
                     <field name="presences" />
                     <field name="day" invisible="1"/>

--- a/event_track_assistant/wizard/wiz_registration_to_another_event.py
+++ b/event_track_assistant/wizard/wiz_registration_to_another_event.py
@@ -7,11 +7,6 @@ from openerp import fields, models, api
 class WizRegistrationToAnotherEvent(models.TransientModel):
     _name = 'wiz.registration.to.another.event'
 
-    event_registration_id = fields.Many2one(
-        string='Registration', comodel_name='event.registration')
-    event_id = fields.Many2one(
-        string='Actual event of registration', comodel_name='event.event',
-        readonly=True)
     new_event_id = fields.Many2one(
         string='New event for the registration', comodel_name='event.event',
         required=True)
@@ -30,16 +25,42 @@ class WizRegistrationToAnotherEvent(models.TransientModel):
 
     @api.multi
     def button_change_registration_event(self):
-        self.event_id.mapped('track_ids.presences').filtered(
-            lambda x: x.partner == self.event_registration_id.partner_id and
-            x.state == 'pending').button_canceled()
-        self._change_registration_event()
-        if self.event_registration_id.state == 'open':
-            self.event_registration_id.state = 'draft'
-            return self.event_registration_id.button_registration_open()
+        confirm_obj = self.env['wiz.event.confirm.assistant']
+        append_obj = self.env['wiz.event.append.assistant']
+        track_obj = self.env['event.track']
+        registrations = self.env['event.registration'].browse(
+            self.env.context['active_ids']).filtered(
+            lambda x: x.state in ('draft', 'open'))
+        for registration in registrations:
+            registration.event_id.mapped('track_ids.presences').filtered(
+                lambda x: x.partner == registration.partner_id and
+                x.state == 'pending').button_canceled()
+            self._change_registration_event(registration)
+            if registration.state == 'open':
+                registration.state = 'draft'
+                append_vals = confirm_obj._prepare_data_confirm_assistant(
+                    registration)
+                append = append_obj.create(append_vals)
+                reg = append._update_create_registration(
+                    registration.event_id, registration)
+                reg.confirm_registration()
+                reg.mail_user()
+                cond = append._prepare_track_condition_search(
+                    self.new_event_id)
+                tracks = track_obj.search(cond)
+                for track in tracks:
+                    presence = track.presences.filtered(
+                        lambda x: x.session == track and
+                        x.event == self.new_event_id and
+                        x.partner == registration.partner_id)
+                    if presence:
+                        append._put_pending_presence_state(presence)
+                    else:
+                        append._create_presence_from_wizard(
+                            track, self.new_event_id)
 
-    def _change_registration_event(self):
-        self.event_registration_id.write({
+    def _change_registration_event(self, registration):
+        registration.write({
             'event_id': self.new_event_id.id,
             'date_start': self.new_event_id.date_begin,
             'date_end': self.new_event_id.date_end,

--- a/event_track_assistant/wizard/wiz_registration_to_another_event_view.xml
+++ b/event_track_assistant/wizard/wiz_registration_to_another_event_view.xml
@@ -7,11 +7,9 @@
             <field name="arch" type="xml">
                 <form string="Change event to registration" version="7.0">
                     <group>
-                        <separator string="Actual event of registration" colspan="4" />
-                        <field name="event_id" nolabel="1" colspan="4" />
-                        <separator string="New event for the registration" colspan="4" />
+                        <separator string="New event for the registrations" colspan="4" />
                         <field name="new_event_id" nolabel="1" colspan="4"
-                               domain="[('id','!=',event_id),('state','not in',('cancel','done'))]" />
+                               domain="[('state','not in',('cancel','done'))]" />
                     </group>
                     <footer>
                         <button name="button_change_registration_event" type="object"
@@ -22,11 +20,12 @@
                 </form>
             </field>
         </record>
-        <act_window name="Change registration to selected new event"
+        <act_window name="Change registration to another event"
                     res_model="wiz.registration.to.another.event"
                     view_mode="form"
                     view_type="form"
                     target="new"
-                    id="action_change_registration_new_event"/>
+                    id="action_change_registration_new_event"
+                    key2="client_action_multi"/>
     </data>
 </openerp>


### PR DESCRIPTION
…gistration form remove button "Change registration to another event", and put it in the context menu.
En el formulario del registro de evento, quitar el botón "Cambiar registro a otro evento", y meter esta opción en el menú contextual "+", para que se puedan seleccionar varios registros para mover a otro evento.