### PR TITLE
[FIX] event_planned_by_sale_line: Select only sale lines that have da…

### DIFF
--- a/event_planned_by_sale_line/__openerp__.py
+++ b/event_planned_by_sale_line/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 {
     "name": "Event Planned By Sale Line",
-    "version": "8.0.1.0.1",
+    "version": "8.0.1.1.0",
     "category": "Custom Module",
     "license": "AGPL-3",
     "author": "AvanzOSC",

--- a/event_planned_by_sale_line/models/sale_order.py
+++ b/event_planned_by_sale_line/models/sale_order.py
@@ -99,8 +99,10 @@ class SaleOrder(models.Model):
                 not self.env.context.get('check_automatic_contract_creation')):
             return True
         for sale in self:
-            min_fec = min(sale.mapped('order_line.start_date'))
-            max_fec = max(sale.mapped('order_line.end_date'))
+            lines = sale.mapped('order_line').filtered(lambda x: x.start_date)
+            min_fec = min(lines.mapped('start_date'))
+            lines = sale.mapped('order_line').filtered(lambda x: x.end_date)
+            max_fec = max(lines.mapped('end_date'))
             if min_fec and max_fec:
                 account_vals = {'sale': sale.id,
                                 'partner_id': sale.partner_id.id,


### PR DESCRIPTION
…tes to create a contract.
Seleccionar solo líneas de ventas que tengan fecha de inicio, y fecha fin para crear automáticamente el contrato del pedido de venta.