### PR TITLE
[FIX] event_registration_hr_contract_hour: Filter sales orders that h…

### DIFF
--- a/event_registration_hr_contract_hour/__openerp__.py
+++ b/event_registration_hr_contract_hour/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 {
     "name": "Event Registration Hr Contract Hour",
-    'version': '8.0.1.1.0',
+    'version': '8.0.1.2.0',
     'license': "AGPL-3",
     'author': "AvanzOSC",
     'website': "http://www.avanzosc.es",

--- a/event_registration_hr_contract_hour/models/sale_order.py
+++ b/event_registration_hr_contract_hour/models/sale_order.py
@@ -11,13 +11,13 @@ class SaleOrder(models.Model):
     def action_button_confirm(self):
         project_obj = self.env['project.project']
         event_obj = self.env['event.event']
-        for sale in self:
+        for sale in self.filtered(lambda x: x.project_id):
             cond = [('analytic_account_id', '=', sale.project_id.id)]
             project = project_obj.search(cond, limit=1)
-            cond = [('project_id', '=', project.id)]
-            events = event_obj.search(cond)
-            for event in events:
-                for track in event.track_ids:
+            if project:
+                cond = [('project_id', '=', project.id)]
+                events = event_obj.search(cond)
+                for track in events.mapped('track_ids'):
                     f = fields.Datetime.from_string(track.session_date).date()
                     day = f.weekday()
                     if day == 6:


### PR DESCRIPTION
…ave a contract.
Tratar pedidos de venta que tengan contrato asociado, y también que este contrato este asignado a un proyecto.