### PR TITLE
[IMP] event_track_assistant: Put followers object in event presences …

### DIFF
--- a/event_substitution/views/event_track_presence_view.xml
+++ b/event_substitution/views/event_track_presence_view.xml
@@ -52,7 +52,7 @@
             -->
             <field name="reply_to">${(object.company_id.email or 'noreply@localhost')|safe}</field>
             <field name="subject">Replacement notice</field>
-            <field name="lang">${object.partner.lang}</field>
+            <field name="lang">${object.partner and object.partner.lang or ''}</field>
             <field name="body_html"><![CDATA[
     <p>Good morning.</p>
     <p>The day ${object.session_date_without_hour} ${object.replaced_by.name} will substitute ${object.partner.name} at customer ${object.event.address_id.name}, in the session ${object.session.name}, at ${object.start_hour} H.</p>

--- a/event_track_assistant/models/event.py
+++ b/event_track_assistant/models/event.py
@@ -275,6 +275,7 @@ class EventTrack(models.Model):
 class EventTrackPresence(models.Model):
     _name = 'event.track.presence'
     _description = 'Session assistants'
+    _inherit = ['mail.thread', 'ir.needaction_mixin']
 
     @api.depends('session', 'session.allowed_partner_ids')
     def _compute_allowed_partner_ids(self):

--- a/event_track_assistant/views/event_track_presence_view.xml
+++ b/event_track_assistant/views/event_track_presence_view.xml
@@ -150,6 +150,10 @@
                             <field name="notes" nolabel="1" colspan="4" />
                         </group>
                     </sheet>
+                    <div class="oe_chatter">
+                        <field name="message_follower_ids" widget="mail_followers"/>
+                        <field name="message_ids" widget="mail_thread"/>
+                    </div>
                 </form>
             </field>
         </record>


### PR DESCRIPTION
…to send emails.
Poner el objeto "seguidores" en presencias de evento para poder mandar emails desde este objeto. Además se ha movido el campo "subject" en el email en el modulo event_substitution.