### PR TITLE
[FIX] event_track_assistant: Put src_model in call to wizard "registr…

### DIFF
--- a/event_track_assistant/wizard/wiz_registration_to_another_event_view.xml
+++ b/event_track_assistant/wizard/wiz_registration_to_another_event_view.xml
@@ -22,6 +22,7 @@
         </record>
         <act_window name="Change registration to another event"
                     res_model="wiz.registration.to.another.event"
+                    src_model="event.registration"
                     view_mode="form"
                     view_type="form"
                     target="new"


### PR DESCRIPTION
…ation to another event".
Poner el parametro "scr_model" en la llamada al wizard para cambiar al registro de evento.