### PR TITLE
[IMP] event_registration_analytic: Set to "open" analytic account sta…

### DIFF
--- a/event_registration_analytic/wizard/wiz_event_append_assistant.py
+++ b/event_registration_analytic/wizard/wiz_event_append_assistant.py
@@ -46,6 +46,8 @@ class WizEventAppendAssistant(models.TransientModel):
             self.registration.analytic_account.write(
                 self._prepare_data_for_account_not_employee(
                     self.registration.event_id, self.registration))
+        if self.registration:
+            self.registration.analytic_account.set_open()
         return result
 
     def _create_account_for_not_employee_from_wizard(


### PR DESCRIPTION
…te when when reconfirming a event registration.
Poner a la cuenta analitica asociada al registro en estado "open", al reconfirmar un registro ya existente.