### PR TITLE
[IMP] event_track_assistant, event_registration_hr_contract: Cancel e…

### DIFF
--- a/event_registration_analytic/tests/test_event_registration_analytic.py
+++ b/event_registration_analytic/tests/test_event_registration_analytic.py
@@ -144,19 +144,15 @@ class TestEventRegistrationAnalytic(TestSaleOrderCreateEventAssistant):
         self.env.ref('base.public_partner').employee_id = (
             self.ref('hr.employee'))
         self.calendar_holiday.lines[0].write({'date': '2016-01-06'})
-        wiz = self.wiz_model.with_context(
-            {'active_id': self.contract.id}).create({'year': self.today.year})
-        vals = ['year']
-        wiz.with_context(
-            {'active_id': self.contract.id}).default_get(vals)
-        wiz.with_context(
-            {'active_id':
-             self.contract.id}).button_calculate_workables_and_festives()
-        cond = [('partner', '=', self.ref('base.public_partner')),
-                ('year', '=', self.today.year)]
-        calendar = self.calendar_model.search(cond)
-        self.assertNotEqual(
-            len(calendar), 0, 'Calendar not generated for partner')
+        calendar_vals = {'partner': self.ref('base.public_partner'),
+                         'year': self.today.year}
+        calendar_line_vals = {
+            'partner': self.ref('base.public_partner'),
+            'date': '{}-01-06'.format(self.today.year),
+            'contract': self.contract.id,
+            'festive': True}
+        calendar_vals['dates'] = [(0, 0, calendar_line_vals)]
+        self.calendar_model.create(calendar_vals)
         self.partner = self.env['res.partner'].create({
             'name': 'Partner',
             'parent_id': self.ref('base.public_partner')
@@ -186,14 +182,15 @@ class TestEventRegistrationAnalytic(TestSaleOrderCreateEventAssistant):
                          'holiday_calendars':
                          [(6, 0, [self.calendar_holiday.id])]}
         self.contract2 = self.contract_model.create(contract_vals)
-        wiz = self.wiz_model.with_context(
-            {'active_id': self.contract2.id}).create({'year': self.today.year})
-        vals = ['year']
-        wiz.with_context(
-            {'active_id': self.contract2.id}).default_get(vals)
-        wiz.with_context(
-            {'active_id':
-             self.contract2.id}).button_calculate_workables_and_festives()
+        calendar_vals = {'partner': self.partner.id,
+                         'year': self.today.year}
+        calendar_line_vals = {
+            'partner': self.partner.id,
+            'date': '{}-01-06'.format(self.today.year),
+            'contract': self.contract2.id,
+            'festive': True}
+        calendar_vals['dates'] = [(0, 0, calendar_line_vals)]
+        self.calendar_model.create(calendar_vals)
         event = self.env.ref('event.event_0')
         event.seats_max = 0
         reg_vals = {

--- a/event_registration_hr_contract/__openerp__.py
+++ b/event_registration_hr_contract/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 {
     "name": "Event Registration Hr Contract",
-    'version': '8.0.1.1.0',
+    'version': '8.0.1.2.0',
     'license': "AGPL-3",
     'author': "AvanzOSC",
     'website': "http://www.avanzosc.es",

--- a/event_registration_hr_contract/models/event.py
+++ b/event_registration_hr_contract/models/event.py
@@ -170,6 +170,15 @@ class EventRegistration(models.Model):
                 _("You must enter the employee's contract"))
         return super(EventRegistration, self).button_registration_open()
 
+    def _cancel_presences(self, from_date, to_date, notes):
+        presences = super(EventRegistration, self)._cancel_presences(
+            from_date, to_date, notes)
+        if self.employee:
+            for presence in presences:
+                presence._update_employee_calendar_days(
+                    contract=False, cancel_presence=True)
+        return presences
+
 
 class EventTrackPresence(models.Model):
     _inherit = 'event.track.presence'

--- a/event_registration_hr_contract/wizard/wiz_event_delete_assistant.py
+++ b/event_registration_hr_contract/wizard/wiz_event_delete_assistant.py
@@ -10,11 +10,3 @@ class WizEventDeleteAssistant(models.TransientModel):
     employee = fields.Many2one(
         comodel_name='hr.employee', related='partner.employee_id',
         string='Employee')
-
-    def _cancel_presences(self):
-        presences = super(WizEventDeleteAssistant, self)._cancel_presences()
-        if self.employee:
-            for presence in presences:
-                presence._update_employee_calendar_days(
-                    contract=False, cancel_presence=True)
-        return presences

--- a/event_track_assistant/__openerp__.py
+++ b/event_track_assistant/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 {
     "name": "Event Track Assistant",
-    "version": "8.0.1.1.0",
+    "version": "8.0.1.2.0",
     "license": "AGPL-3",
     "author": "AvanzOSC",
     "website": "http://www.avanzosc.es",

--- a/event_track_assistant/tests/test_event_track_assistant.py
+++ b/event_track_assistant/tests/test_event_track_assistant.py
@@ -257,6 +257,10 @@ class TestEventTrackAssistant(EventTrackAssistantSetup):
         registration = self.event.registration_ids.filtered(
             lambda r: r.partner_id == self.partner)
         self.assertEquals(registration.state, 'cancel')
+        registration._cancel_registration(
+            '2025-01-29', '2025-01-30', '2025-01-01', 'notes')
+        registration._cancel_registration(
+            '2025-01-20', '2025-01-25', '2025-01-01', 'notes')
 
     def test_event_assistant_track_assistant_confirm_assistant(self):
         add_wiz = self.wiz_add_model.with_context(

--- a/sale_order_create_event_hour/wizard/wiz_event_delete_assistant.py
+++ b/sale_order_create_event_hour/wizard/wiz_event_delete_assistant.py
@@ -42,12 +42,3 @@ class WizEventDeleteAssistant(models.TransientModel):
             self.min_from_date, tz=tz), tz=tz)
         self.end_time = _convert_time_to_float(_convert_to_utc_date(
             self.max_to_date, tz=tz), tz=tz)
-
-    def _update_registration_date_end(self, registration):
-        super(WizEventDeleteAssistant, self)._update_registration_date_end(
-            registration)
-        reg_date_end = str2datetime(registration.date_end)
-        wiz_from_date = _convert_to_utc_date(
-            self.from_date, time=self.start_time, tz=self.env.user.tz)
-        if wiz_from_date != reg_date_end:
-            registration.date_end = wiz_from_date


### PR DESCRIPTION
…vent registrations from the object itself, and not from the wizard.
Cancelar registros de eventos desde el propio objeto, y no desde el wizard.
También se ha modificado el test de "event_registration_analytic" para bajar tiempos.