### PR TITLE
[ADD] event_registration_no_bank: Do not show error if the student do…

### DIFF
--- a/event_registration_no_bank/README.rst
+++ b/event_registration_no_bank/README.rst
@@ -1,0 +1,18 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==========================
+Event registration no bank
+==========================
+
+* Do not show error if the student does not have a SEPA mandate.
+
+Credits
+=======
+
+
+Contributors
+------------
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/event_registration_no_bank/__init__.py
+++ b/event_registration_no_bank/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import models

--- a/event_registration_no_bank/__openerp__.py
+++ b/event_registration_no_bank/__openerp__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+{
+    "name": "Event Registration No Bank",
+    "version": "8.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "AvanzOSC",
+    "website": "http://www.avanzosc.es",
+    "contributors": [
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        "Alfredo de la Fuente <alfredodelafuente@avanzosc.es>",
+    ],
+    "category": "Event Management",
+    "depends": [
+        "event_registration_sepa",
+    ],
+    'data': [],
+    "installable": True,
+}

--- a/event_registration_no_bank/i18n/es.po
+++ b/event_registration_no_bank/i18n/es.po
@@ -1,0 +1,22 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* event_registration_no_bank
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-01 06:17+0000\n"
+"PO-Revision-Date: 2018-06-01 06:17+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: event_registration_no_bank
+#: model:ir.model,name:event_registration_no_bank.model_event_registration
+msgid "Event Registration"
+msgstr "Registro evento"
+

--- a/event_registration_no_bank/models/__init__.py
+++ b/event_registration_no_bank/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import event_registration

--- a/event_registration_no_bank/models/event_registration.py
+++ b/event_registration_no_bank/models/event_registration.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Copyright Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models
+
+
+class EventRegistration(models.Model):
+    _inherit = 'event.registration'
+
+    def show_sepa_mandate_error(self):
+        pass

--- a/event_registration_no_bank/tests/__init__.py
+++ b/event_registration_no_bank/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import test_event_registration_no_bank

--- a/event_registration_no_bank/tests/test_event_registration_no_bank.py
+++ b/event_registration_no_bank/tests/test_event_registration_no_bank.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+import openerp.tests.common as common
+
+
+class TestEventRegistrationNoBank(common.TransactionCase):
+
+    def setUp(self):
+        super(TestEventRegistrationNoBank, self).setUp()
+        self.sale_order_model = self.env['sale.order']
+        self.event = self.env.ref('event.event_1')
+        self.partner = self.env.ref('base.res_partner_address_23')
+
+    def test_event_registration_no_bank(self):
+        cond = [('payer', '=', 'student')]
+        self.event.sale_order = self.sale_order_model.search(cond, limit=1)
+        self.event.registration_ids[0].partner_id = self.partner.id
+        self.event.registration_ids[0].with_context(
+            check_mandate_sepa=True).registration_open()
+        self.event.registration_ids[0].registration_open()

--- a/event_registration_sepa/__openerp__.py
+++ b/event_registration_sepa/__openerp__.py
@@ -19,6 +19,7 @@
         "account_payment_sale",
         "hr_employee_catch_partner",
         "event_registration_analytic",
+        "event_planned_by_sale_line"
     ],
     'data': ['views/payment_mode_view.xml',
              ],

--- a/event_registration_sepa/models/event.py
+++ b/event_registration_sepa/models/event.py
@@ -22,7 +22,10 @@ class EventRegistration(models.Model):
             (self.event_id.sale_order.payer == 'student' and
              self.parent_num_valid_mandates == 0 and not
              self.partner_id.employee_id)):
-            raise exceptions.Warning(
-                _('%s needs a valid sepa mandate for confirm the assistant!')
-                % self.partner_id.name)
+            self.show_sepa_mandate_error()
         return super(EventRegistration, self).registration_open()
+
+    def show_sepa_mandate_error(self):
+        raise exceptions.Warning(
+            _('%s needs a valid sepa mandate for confirm the assistant!')
+            % self.partner_id.name)

--- a/event_track_presence_claim/tests/test_event_track_presence_claim.py
+++ b/event_track_presence_claim/tests/test_event_track_presence_claim.py
@@ -47,12 +47,19 @@ class TestEventTrackPresenceClaim(common.TransactionCase):
         event_vals = {'name': 'Test crm claim event presence',
                       'date_begin': date_begin,
                       'date_end': date_end,
-                      'warnings_not_imputations_count': 2,
+                      'warnings_not_imputations_count': 1,
                       'track_ids': tracks}
         self.event = self.env['event.event'].create(event_vals)
 
     def test_event_track_presence_claim(self):
         self.env['event.track']._search_no_imputations_and_create_claim()
+        self.assertEqual(
+            self.event.warnings_not_imputations_count, 2,
+            'Bad imputations counter')
+        self.env['event.track']._search_no_imputations_and_create_claim()
         cond = [('event_id', '=', self.event.id)]
         claims = self.env['crm.claim'].search(cond)
         self.assertEqual(len(claims), 3, 'Claims not found')
+        self.event.track_ids[0].presences.write({'state': 'completed'})
+        res = self.event.track_ids[0]._find_pending_presences()
+        self.assertEqual(res, False, 'Presences found')


### PR DESCRIPTION
…es not have a SEPA mandate.
Nuevo módulo para que cuando se confirme un alumno que no tiene un mandato SEPA, no muestre el error.
Se ha tenido que modificar también el módulo "event_registration_sepa", para sacar el RAISE que muestra dicho error a una función.