### PR TITLE
[FIX] event_planned_by_sale_line: Fix activate months in sales order …

### DIFF
--- a/event_planned_by_sale_line/models/sale_order.py
+++ b/event_planned_by_sale_line/models/sale_order.py
@@ -4,6 +4,7 @@
 from openerp import fields, models, api, _
 from openerp.tools import config
 import calendar
+from dateutil.relativedelta import relativedelta
 
 
 class SaleOrder(models.Model):
@@ -194,9 +195,12 @@ class SaleOrderLine(models.Model):
     def onchange_start_end_date(self):
         self.ensure_one()
         if self.start_date and self.end_date:
-            fec_ini = fields.Date.from_string(self.start_date)
-            fec_fin = fields.Date.from_string(self.end_date)
-            months = list(range(fec_ini.month, fec_fin.month + 1))
+            fec_ini = fields.Date.from_string(self.start_date).replace(day=1)
+            fec_fin = fields.Date.from_string(self.end_date).replace(day=1)
+            months = []
+            while fec_ini <= fec_fin:
+                months.append(fec_ini.month)
+                fec_ini += relativedelta(months=1)
             self.january = 1 in months
             self.february = 2 in months
             self.march = 3 in months

--- a/event_planned_by_sale_line/tests/test_event_planned_by_sale_line.py
+++ b/event_planned_by_sale_line/tests/test_event_planned_by_sale_line.py
@@ -258,3 +258,41 @@ class TestEventPlannedBySaleLine(TestEventRegistrationAnalytic):
         self.partner.payer = 'school'
         res = self.sale_order.onchange_partner_id(self.partner.id)
         self.assertEqual(res['value'].get('payer', False), 'school')
+
+    def test_onchange_start_end_date_different_year(self):
+        line = self.sale_line_model.new({
+            'start_date': self.today.replace(month=9),
+            'end_date': self.today.replace(month=5, year=self.today.year+1),
+        })
+        line.onchange_start_end_date()
+        self.assertTrue(line.january)
+        self.assertTrue(line.february)
+        self.assertTrue(line.march)
+        self.assertTrue(line.april)
+        self.assertTrue(line.may)
+        self.assertFalse(line.june)
+        self.assertFalse(line.july)
+        self.assertFalse(line.august)
+        self.assertTrue(line.september)
+        self.assertTrue(line.october)
+        self.assertTrue(line.november)
+        self.assertTrue(line.december)
+
+    def test_onchange_start_end_date_two_different_year(self):
+        line = self.sale_line_model.new({
+            'start_date': self.today.replace(month=9),
+            'end_date': self.today.replace(month=5, year=self.today.year+2),
+        })
+        line.onchange_start_end_date()
+        self.assertTrue(line.january)
+        self.assertTrue(line.february)
+        self.assertTrue(line.march)
+        self.assertTrue(line.april)
+        self.assertTrue(line.may)
+        self.assertTrue(line.june)
+        self.assertTrue(line.july)
+        self.assertTrue(line.august)
+        self.assertTrue(line.september)
+        self.assertTrue(line.october)
+        self.assertTrue(line.november)
+        self.assertTrue(line.december)

--- a/event_registration_analytic/__openerp__.py
+++ b/event_registration_analytic/__openerp__.py
@@ -26,7 +26,7 @@
         "event_registration_hr_contract",
         "event_substitution",
         "payment_line_menu",
-        "account_payment",
+        "account_payment_sale",
     ],
     "data": [
         "security/ir.model.access.csv",


### PR DESCRIPTION
…lines.
Se estaban activando mal los meses de las líneas de pedido de venta, cuando el año era distinto entre la fecha desde, y la fecha hasta.