### PR TITLE
[IMP] event_planned_by_sale_line: Do not create a sales contract if a…

### DIFF
--- a/event_planned_by_sale_line/models/sale_order.py
+++ b/event_planned_by_sale_line/models/sale_order.py
@@ -65,7 +65,7 @@ class SaleOrder(models.Model):
 
     @api.multi
     def action_button_confirm(self):
-        for sale in self:
+        for sale in self.filtered(lambda x: not x.project_id):
             if any(sale.mapped('order_line.product_id.recurring_service')):
                 sale._create_automatic_contract_from_sale()
         res = super(SaleOrder, self).action_button_confirm()

--- a/event_planned_by_sale_line/tests/test_event_planned_by_sale_line.py
+++ b/event_planned_by_sale_line/tests/test_event_planned_by_sale_line.py
@@ -296,3 +296,7 @@ class TestEventPlannedBySaleLine(TestEventRegistrationAnalytic):
         self.assertTrue(line.october)
         self.assertTrue(line.november)
         self.assertTrue(line.december)
+
+    def test_check_automatic_contract_creation(self):
+        result = self.sale_order._create_automatic_contract_from_sale()
+        self.assertEquals(result, True)


### PR DESCRIPTION
…lready have one.
No crear un contrato automáticamente en el pedido de venta, si este ya tiene uno definido.