### PR TITLE
[IMP] sale_order_renovate_event: Segun se renueve el pedido de venta/…

### DIFF
--- a/sale_order_renovate_event/__openerp__.py
+++ b/sale_order_renovate_event/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 {
     "name": "Sale Order Renovate Event",
-    "version": "8.0.1.0.0",
+    "version": "8.0.1.1.0",
     "license": "AGPL-3",
     "author": "AvanzOSC",
     "website": "http://www.avanzosc.es",

--- a/sale_order_renovate_event/models/sale_order.py
+++ b/sale_order_renovate_event/models/sale_order.py
@@ -7,6 +7,9 @@ from openerp import models, fields, api
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
+    generated_next_year = fields.Boolean(
+        string='Generated Next Year', default=False)
+
     @api.multi
     def automatic_renovate_contract_event(self):
         sale_orders = self.env['sale.order']
@@ -16,7 +19,8 @@ class SaleOrder(models.Model):
                 ('project_id.state', '=', 'open'),
                 ('project_id.type', '=', 'contract'),
                 ('project_id.recurring_invoices', '=', True),
-                ('project_id.date', '=', date)]
+                ('project_id.date', '=', date),
+                ('generated_next_year', '=', False)]
         sales = self.search(cond)
         for sale in sales:
             cond = [('sale_order', '=', sale.id)]
@@ -30,5 +34,7 @@ class SaleOrder(models.Model):
                         ('order_line', '!=', False)]
                 new_sale = self.env['sale.order'].search(cond, limit=1)
                 new_sale.action_button_confirm()
+                sale.generated_next_year = True
+                self.env.cr.commit()
             except Exception:
                 continue


### PR DESCRIPTION
…contrato, que esté ya disponible.
Segun se halla generado el nuevo pedido de venta, y evento, que estén disponibles en el sistema, sin estar esperando a que termine el proceso de todos los pedidos de vneta.